### PR TITLE
use 'RequestContext' as the second argument of interactors

### DIFF
--- a/packages/api/src/components/AppBuilder.ts
+++ b/packages/api/src/components/AppBuilder.ts
@@ -10,7 +10,7 @@ import { Authenticator } from './Authenticator'
 import { Configuration } from './Configuration'
 import { getLogger } from '~middleware'
 import { resolvers, directiveResolvers } from '~resolvers'
-import { AppContext, AsyncProvider, BuiltAppContext, RequestContext } from '~types'
+import { AppContext, AsyncProvider, BuiltAppContext } from '~types'
 import fastify, { FastifyReply, FastifyRequest } from 'fastify'
 import { getSchema } from '~utils/getSchema'
 

--- a/packages/api/src/interactors/AddEngagementInteractor.ts
+++ b/packages/api/src/interactors/AddEngagementInteractor.ts
@@ -9,9 +9,9 @@ import {
 } from '@cbosuite/schema/dist/provider-types'
 import { PubSub } from 'graphql-subscriptions'
 import { Localization } from '~components'
-import { DbAction, DbUser, EngagementCollection, UserCollection } from '~db'
+import { DbAction, EngagementCollection, UserCollection } from '~db'
 import { createDBAction, createDBMention, createGQLEngagement, createGQLMention } from '~dto'
-import { Interactor } from '~types'
+import { Interactor, RequestContext } from '~types'
 import { sortByDate } from '~utils'
 
 export class AddEngagementInteractor
@@ -36,7 +36,7 @@ export class AddEngagementInteractor
 
 	public async execute(
 		body: EngagementActionInput,
-		identity?: DbUser | null
+		{ identity }: RequestContext
 	): Promise<EngagementResponse> {
 		const { engId: id, action } = body
 		if (!action.userId) {

--- a/packages/api/src/interactors/AssignEngagementInteractor.ts
+++ b/packages/api/src/interactors/AssignEngagementInteractor.ts
@@ -9,7 +9,7 @@ import {
 } from '@cbosuite/schema/dist/provider-types'
 import { PubSub } from 'graphql-subscriptions'
 import { Localization, Notifications } from '~components'
-import { DbAction, DbUser, EngagementCollection, UserCollection } from '~db'
+import { DbAction, EngagementCollection, UserCollection } from '~db'
 import { createDBAction, createGQLEngagement, createGQLUser } from '~dto'
 import { Interactor, RequestContext } from '~types'
 import { sortByDate } from '~utils'

--- a/packages/api/src/interactors/AssignEngagementInteractor.ts
+++ b/packages/api/src/interactors/AssignEngagementInteractor.ts
@@ -11,7 +11,7 @@ import { PubSub } from 'graphql-subscriptions'
 import { Localization, Notifications } from '~components'
 import { DbAction, DbUser, EngagementCollection, UserCollection } from '~db'
 import { createDBAction, createGQLEngagement, createGQLUser } from '~dto'
-import { Interactor } from '~types'
+import { Interactor, RequestContext } from '~types'
 import { sortByDate } from '~utils'
 
 export class AssignEngagementInteractor
@@ -37,7 +37,10 @@ export class AssignEngagementInteractor
 		this.#notifier = notifier
 	}
 
-	public async execute(body: EngagementUserInput, identity: DbUser): Promise<EngagementResponse> {
+	public async execute(
+		body: EngagementUserInput,
+		{ identity }: RequestContext
+	): Promise<EngagementResponse> {
 		const { engId: id, userId } = body
 		const [engagement, user] = await Promise.all([
 			this.#engagements.itemById(id),

--- a/packages/api/src/interactors/CompleteEngagementInteractor.ts
+++ b/packages/api/src/interactors/CompleteEngagementInteractor.ts
@@ -10,7 +10,7 @@ import {
 } from '@cbosuite/schema/dist/provider-types'
 import { PubSub } from 'graphql-subscriptions'
 import { Localization } from '~components'
-import { DbUser, EngagementCollection } from '~db'
+import { EngagementCollection } from '~db'
 import { createDBAction, createGQLEngagement } from '~dto'
 import { Interactor, RequestContext } from '~types'
 import { sortByDate } from '~utils'

--- a/packages/api/src/interactors/CompleteEngagementInteractor.ts
+++ b/packages/api/src/interactors/CompleteEngagementInteractor.ts
@@ -12,7 +12,7 @@ import { PubSub } from 'graphql-subscriptions'
 import { Localization } from '~components'
 import { DbUser, EngagementCollection } from '~db'
 import { createDBAction, createGQLEngagement } from '~dto'
-import { Interactor } from '~types'
+import { Interactor, RequestContext } from '~types'
 import { sortByDate } from '~utils'
 
 export class CompleteEngagementInteractor
@@ -32,7 +32,10 @@ export class CompleteEngagementInteractor
 		this.#pubsub = pubsub
 	}
 
-	public async execute(body: EngagementIdInput, identity: DbUser): Promise<EngagementResponse> {
+	public async execute(
+		body: EngagementIdInput,
+		{ identity }: RequestContext
+	): Promise<EngagementResponse> {
 		const { engId: id } = body
 		if (!identity) {
 			return {

--- a/packages/api/src/interactors/SetEngagementStatusInteractor.ts
+++ b/packages/api/src/interactors/SetEngagementStatusInteractor.ts
@@ -13,7 +13,7 @@ import { PubSub } from 'graphql-subscriptions'
 import { Localization } from '~components'
 import { DbUser, EngagementCollection } from '~db'
 import { createDBAction, createGQLEngagement } from '~dto'
-import { Interactor } from '~types'
+import { Interactor, RequestContext } from '~types'
 import { sortByDate } from '~utils'
 
 export class SetEngagementStatusInteractor
@@ -33,7 +33,7 @@ export class SetEngagementStatusInteractor
 		this.#pubsub = pubsub
 	}
 
-	public async execute(body: EngagementStatusInput, identity?: DbUser | null) {
+	public async execute(body: EngagementStatusInput, { identity }: RequestContext) {
 		const { engId: id, status } = body
 		const engagement = await this.#engagements.itemById(id)
 		if (!engagement.item) {

--- a/packages/api/src/interactors/SetEngagementStatusInteractor.ts
+++ b/packages/api/src/interactors/SetEngagementStatusInteractor.ts
@@ -11,7 +11,7 @@ import {
 } from '@cbosuite/schema/dist/provider-types'
 import { PubSub } from 'graphql-subscriptions'
 import { Localization } from '~components'
-import { DbUser, EngagementCollection } from '~db'
+import { EngagementCollection } from '~db'
 import { createDBAction, createGQLEngagement } from '~dto'
 import { Interactor, RequestContext } from '~types'
 import { sortByDate } from '~utils'

--- a/packages/api/src/interactors/SetUserPasswordInteractor.ts
+++ b/packages/api/src/interactors/SetUserPasswordInteractor.ts
@@ -8,9 +8,8 @@ import {
 	UserActionResponse
 } from '@cbosuite/schema/dist/provider-types'
 import { Authenticator, Localization } from '~components'
-import { DbUser } from '~db'
 import { createGQLUser } from '~dto'
-import { Interactor } from '~types'
+import { Interactor, RequestContext } from '~types'
 import { validatePassword } from '~utils'
 
 export class SetUserPasswordInteractor
@@ -26,10 +25,16 @@ export class SetUserPasswordInteractor
 
 	public async execute(
 		body: PasswordChangeInput,
-		identity?: DbUser | null
+		{ identity: user }: RequestContext
 	): Promise<UserActionResponse> {
 		const { oldPassword, newPassword } = body
-		const user = identity as DbUser
+		if (!user) {
+			return {
+				user: null,
+				message: this.#localization.t('mutation.setUserPassword.notLoggedIn'),
+				status: StatusType.Failed
+			}
+		}
 
 		if (!validatePassword(oldPassword, user.password)) {
 			return {

--- a/packages/api/src/interactors/UpdateEngagementInteractor.ts
+++ b/packages/api/src/interactors/UpdateEngagementInteractor.ts
@@ -9,9 +9,9 @@ import {
 } from '@cbosuite/schema/dist/provider-types'
 import { PubSub } from 'graphql-subscriptions'
 import { Localization } from '~components'
-import { DbAction, DbEngagement, DbUser, EngagementCollection, UserCollection } from '~db'
+import { DbAction, DbEngagement, EngagementCollection, UserCollection } from '~db'
 import { createDBAction, createGQLEngagement } from '~dto'
-import { Interactor } from '~types'
+import { Interactor, RequestContext } from '~types'
 import { sortByDate } from '~utils'
 
 export class UpdateEngagementInteractor implements Interactor<EngagementInput, EngagementResponse> {
@@ -32,7 +32,10 @@ export class UpdateEngagementInteractor implements Interactor<EngagementInput, E
 		this.#users = users
 	}
 
-	public async execute(body: EngagementInput, identity: DbUser): Promise<EngagementResponse> {
+	public async execute(
+		body: EngagementInput,
+		{ identity }: RequestContext
+	): Promise<EngagementResponse> {
 		if (!body?.engagementId) {
 			throw Error(this.#localization.t('mutation.updateEngagement.noRequestId'))
 		}

--- a/packages/api/src/interactors/UpdateUserFCMTokenInteractor.ts
+++ b/packages/api/src/interactors/UpdateUserFCMTokenInteractor.ts
@@ -4,8 +4,8 @@
  */
 import { StatusType, UserFcmInput, VoidResponse } from '@cbosuite/schema/dist/provider-types'
 import { Localization } from '~components'
-import { DbUser, UserCollection } from '~db'
-import { Interactor } from '~types'
+import { UserCollection } from '~db'
+import { Interactor, RequestContext } from '~types'
 
 export class UpdateUserFCMTokenInteractor implements Interactor<UserFcmInput, VoidResponse> {
 	#localization: Localization
@@ -16,7 +16,7 @@ export class UpdateUserFCMTokenInteractor implements Interactor<UserFcmInput, Vo
 		this.#users = users
 	}
 
-	public async execute(body: UserFcmInput, identity?: DbUser | null): Promise<VoidResponse> {
+	public async execute(body: UserFcmInput, { identity }: RequestContext): Promise<VoidResponse> {
 		if (!body.fcmToken)
 			return {
 				message: this.#localization.t('mutation.updateUser.failed'),

--- a/packages/api/src/interactors/UpdateUserInteractor.ts
+++ b/packages/api/src/interactors/UpdateUserInteractor.ts
@@ -4,7 +4,7 @@
  */
 import { StatusType, UserInput, UserResponse } from '@cbosuite/schema/dist/provider-types'
 import { Localization } from '~components'
-import { DbRole, DbUser, UserCollection } from '~db'
+import { DbRole, UserCollection } from '~db'
 import { createGQLUser } from '~dto'
 import { Interactor } from '~types'
 
@@ -17,7 +17,7 @@ export class UpdateUserInteractor implements Interactor<UserInput, UserResponse>
 		this.#users = users
 	}
 
-	public async execute(user: UserInput, identity?: DbUser | null): Promise<UserResponse> {
+	public async execute(user: UserInput): Promise<UserResponse> {
 		if (!user.id) {
 			return {
 				user: null,

--- a/packages/api/src/locales/en-US/mutation.json
+++ b/packages/api/src/locales/en-US/mutation.json
@@ -168,6 +168,8 @@
 		"_invalidTokenExpired.comment": "Password token expired error message"
 	},
 	"setUserPassword": {
+		"notLoggedIn": "User is not logged in",
+		"_notLoggedIn.comment": "The user must be logged in so that they can reset their password",
 		"invalidPassword": "Current password is invalid",
 		"_invalidPassword.comment": "Current password is invalid error message",
 		"resetError": "Error resetting password",

--- a/packages/api/src/resolvers/Mutation/index.ts
+++ b/packages/api/src/resolvers/Mutation/index.ts
@@ -6,81 +6,84 @@ import { MutationResolvers } from '@cbosuite/schema/dist/provider-types'
 import { AppContext } from '~types'
 
 export const Mutation: MutationResolvers<AppContext> = {
-	authenticate: (_, { body }, { auth, interactors: { authenticate } }) =>
-		authenticate.execute(body, auth.identity),
+	authenticate: (_, { body }, { requestCtx, interactors: { authenticate } }) =>
+		authenticate.execute(body, requestCtx),
 
-	createEngagement: (_, { body }, { auth, interactors: { createEngagement } }) =>
-		createEngagement.execute(body, auth.identity),
+	createEngagement: (_, { body }, { requestCtx, interactors: { createEngagement } }) =>
+		createEngagement.execute(body, requestCtx),
 
-	updateEngagement: async (_, { body }, { auth, interactors: { updateEngagement } }) =>
-		updateEngagement.execute(body, auth.identity),
+	updateEngagement: async (_, { body }, { requestCtx, interactors: { updateEngagement } }) =>
+		updateEngagement.execute(body, requestCtx),
 
-	assignEngagement: async (_, { body }, { auth, interactors: { assignEngagement } }) =>
-		assignEngagement.execute(body, auth.identity),
+	assignEngagement: async (_, { body }, { requestCtx, interactors: { assignEngagement } }) =>
+		assignEngagement.execute(body, requestCtx),
 
-	completeEngagement: async (_, { body }, { auth, interactors: { completeEngagement } }) =>
-		completeEngagement.execute(body, auth.identity),
+	completeEngagement: async (_, { body }, { requestCtx, interactors: { completeEngagement } }) =>
+		completeEngagement.execute(body, requestCtx),
 
-	setEngagementStatus: async (_, { body }, { auth, interactors: { setEngagementStatus } }) =>
-		setEngagementStatus.execute(body, auth.identity),
+	setEngagementStatus: async (_, { body }, { requestCtx, interactors: { setEngagementStatus } }) =>
+		setEngagementStatus.execute(body, requestCtx),
 
-	addEngagementAction: async (_, { body }, { auth, interactors: { addEngagement } }) =>
-		addEngagement.execute(body, auth.identity),
+	addEngagementAction: async (_, { body }, { requestCtx, interactors: { addEngagement } }) =>
+		addEngagement.execute(body, requestCtx),
 
-	forgotUserPassword: async (_, { body }, { auth, interactors: { forgotUserPassword } }) =>
-		forgotUserPassword.execute(body, auth.identity),
+	forgotUserPassword: async (_, { body }, { requestCtx, interactors: { forgotUserPassword } }) =>
+		forgotUserPassword.execute(body, requestCtx),
 
 	validateResetUserPasswordToken: async (
 		_,
 		{ body },
-		{ auth, interactors: { validateResetUserPasswordToken } }
-	) => validateResetUserPasswordToken.execute(body, auth.identity),
+		{ requestCtx, interactors: { validateResetUserPasswordToken } }
+	) => validateResetUserPasswordToken.execute(body, requestCtx),
 
-	changeUserPassword: async (_, { body }, { auth, interactors: { changeUserPassword } }) =>
-		changeUserPassword.execute(body, auth.identity),
+	changeUserPassword: async (_, { body }, { requestCtx, interactors: { changeUserPassword } }) =>
+		changeUserPassword.execute(body, requestCtx),
 
-	resetUserPassword: async (_, { body }, { auth, interactors: { resetUserPassword } }) =>
-		resetUserPassword.execute(body, auth.identity),
+	resetUserPassword: async (_, { body }, { requestCtx, interactors: { resetUserPassword } }) =>
+		resetUserPassword.execute(body, requestCtx),
 
-	setUserPassword: async (_, { body }, { auth, interactors: { setUserPassword } }) =>
-		setUserPassword.execute(body, auth.identity),
+	setUserPassword: async (_, { body }, { requestCtx, interactors: { setUserPassword } }) =>
+		setUserPassword.execute(body, requestCtx),
 
-	createNewUser: async (_, { body }, { auth, interactors: { createNewUser } }) =>
-		createNewUser.execute(body, auth.identity),
+	createNewUser: async (_, { body }, { requestCtx, interactors: { createNewUser } }) =>
+		createNewUser.execute(body, requestCtx),
 
-	updateUser: async (_, { body }, { auth, interactors: { updateUser } }) =>
-		updateUser.execute(body, auth.identity),
+	updateUser: async (_, { body }, { requestCtx, interactors: { updateUser } }) =>
+		updateUser.execute(body, requestCtx),
 
-	updateUserFCMToken: async (_, { body }, { auth, interactors: { updateUserFCMToken } }) =>
-		updateUserFCMToken.execute(body, auth.identity),
+	updateUserFCMToken: async (_, { body }, { requestCtx, interactors: { updateUserFCMToken } }) =>
+		updateUserFCMToken.execute(body, requestCtx),
 
-	markMentionSeen: async (_, { body }, { auth, interactors: { markMentionSeen } }) =>
-		markMentionSeen.execute(body, auth.identity),
+	markMentionSeen: async (_, { body }, { requestCtx, interactors: { markMentionSeen } }) =>
+		markMentionSeen.execute(body, requestCtx),
 
-	markMentionDismissed: async (_, { body }, { auth, interactors: { markMentionDismissed } }) =>
-		markMentionDismissed.execute(body, auth.identity),
+	markMentionDismissed: async (
+		_,
+		{ body },
+		{ requestCtx, interactors: { markMentionDismissed } }
+	) => markMentionDismissed.execute(body, requestCtx),
 
-	createNewTag: async (_, { body }, { auth, interactors: { createNewTag } }) =>
-		createNewTag.execute(body, auth.identity),
+	createNewTag: async (_, { body }, { requestCtx, interactors: { createNewTag } }) =>
+		createNewTag.execute(body, requestCtx),
 
-	updateTag: async (_, { body }, { auth, interactors: { updateTag } }) =>
-		updateTag.execute(body, auth.identity),
+	updateTag: async (_, { body }, { requestCtx, interactors: { updateTag } }) =>
+		updateTag.execute(body, requestCtx),
 
-	createContact: async (_, { body }, { auth, interactors: { createContact } }) =>
-		createContact.execute(body, auth.identity),
+	createContact: async (_, { body }, { requestCtx, interactors: { createContact } }) =>
+		createContact.execute(body, requestCtx),
 
-	updateContact: async (_, { body }, { auth, interactors: { updateContact } }) =>
-		updateContact.execute(body, auth.identity),
+	updateContact: async (_, { body }, { requestCtx, interactors: { updateContact } }) =>
+		updateContact.execute(body, requestCtx),
 
-	createAttribute: async (_, { body }, { auth, interactors: { createAttribute } }) =>
-		createAttribute.execute(body, auth.identity),
+	createAttribute: async (_, { body }, { requestCtx, interactors: { createAttribute } }) =>
+		createAttribute.execute(body, requestCtx),
 
-	updateAttribute: async (_, { body }, { auth, interactors: { updateAttribute } }) =>
-		updateAttribute.execute(body, auth.identity),
+	updateAttribute: async (_, { body }, { requestCtx, interactors: { updateAttribute } }) =>
+		updateAttribute.execute(body, requestCtx),
 
-	createService: async (_, { body }, { auth, interactors: { createService } }) =>
-		createService.execute(body, auth.identity),
+	createService: async (_, { body }, { requestCtx, interactors: { createService } }) =>
+		createService.execute(body, requestCtx),
 
-	updateService: async (_, { body }, { auth, interactors: { updateService } }) =>
-		updateService.execute(body, auth.identity)
+	updateService: async (_, { body }, { requestCtx, interactors: { updateService } }) =>
+		updateService.execute(body, requestCtx)
 }

--- a/packages/api/src/resolvers/directiveResolvers.ts
+++ b/packages/api/src/resolvers/directiveResolvers.ts
@@ -8,7 +8,7 @@ import { AppContext } from '~types'
 
 export const directiveResolvers: Record<string, DirectiveResolverFn> = {
 	auth(next: NextResolverFn, src: any, args: Record<string, any>, context: AppContext) {
-		if (!context.auth.identity) {
+		if (!context.requestCtx.identity) {
 			throw new Error(`Insufficient access: user not authenticated`)
 		}
 		return next()
@@ -21,8 +21,7 @@ export const directiveResolvers: Record<string, DirectiveResolverFn> = {
 		context: AppContext
 	) {
 		const role = args.requires || RoleType.User
-		const { orgId } = context
-		const user = context.auth.identity
+		const { orgId, identity: user } = context.requestCtx
 		const authenticator = context.components.authenticator
 
 		if (!user) {

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -48,7 +48,7 @@ import { PubSub } from 'graphql-subscriptions'
 import { Transporter } from 'nodemailer'
 
 export interface Interactor<I, O> {
-	execute(input: I, user: DbUser | null): Promise<O>
+	execute(input: I, requestCtx: RequestContext): Promise<O>
 }
 
 export interface Provider<T> {
@@ -119,12 +119,15 @@ export interface BuiltAppContext {
 	}
 }
 
+export interface RequestContext {
+	identity: User | null // requesting user auth identity
+	userId: string | null // requesting user id
+	orgId: string | null // requesting org id
+	locale: string
+}
+
 export interface AppContext extends BuiltAppContext {
-	auth: {
-		identity: User | null // requesting user auth identity
-	}
-	userId: string // requesting user id
-	orgId: string // requesting org id
+	requestCtx: RequestContext
 }
 
 export interface HealthStatus {


### PR DESCRIPTION
A context argument makes a lot of sense for the general interactor signature - this will let us pass around additional request-scoped details such as organization & locale.