### PR TITLE
Add Config-based guard against accidental DB migration/seeding

### DIFF
--- a/packages/api/config/default.json
+++ b/packages/api/config/default.json
@@ -14,6 +14,7 @@
 	"db": {
 		"automigrate": false,
 		"seedMockData": false,
+		"seedConnectionString": null,
 		"connectionString": null,
 		"database": "greenlight",
 		"usersCollection": "users",

--- a/packages/api/config/development.json
+++ b/packages/api/config/development.json
@@ -2,6 +2,7 @@
 	"db": {
 		"automigrate": true,
 		"seedMockData": true,
+		"seedConnectionString": "mongodb://localhost:27017",
 		"connectionString": "mongodb://localhost:27017"
 	}
 }

--- a/packages/api/src/components/Configuration.ts
+++ b/packages/api/src/components/Configuration.ts
@@ -94,6 +94,10 @@ export class Configuration {
 		return this.c.get<boolean>('db.seedMockData')
 	}
 
+	public get dbSeedConnectionString(): boolean {
+		return this.c.get<boolean>('db.seedConnectionString')
+	}
+
 	public get defaultPageOffset(): number {
 		return this.c.get<number>('constants.defaultPageOffset')
 	}

--- a/packages/api/src/components/Configuration.ts
+++ b/packages/api/src/components/Configuration.ts
@@ -94,8 +94,8 @@ export class Configuration {
 		return this.c.get<boolean>('db.seedMockData')
 	}
 
-	public get dbSeedConnectionString(): boolean {
-		return this.c.get<boolean>('db.seedConnectionString')
+	public get dbSeedConnectionString(): string {
+		return this.c.get<string>('db.seedConnectionString')
 	}
 
 	public get defaultPageOffset(): number {


### PR DESCRIPTION
If a developer overrides DB_CONNECTION_STRING to connect to integ (or production for that matter), the autoseeding logic will take place. This PR adds a guard to verify that DB_CONNECTION_STRING has not been overridden for autoseeding logic