### PR TITLE
Add index to user_token collection to handle order queries

### DIFF
--- a/packages/api/migrations/20211005061317-token_creation_index.ts
+++ b/packages/api/migrations/20211005061317-token_creation_index.ts
@@ -1,0 +1,15 @@
+/*!
+ * Copyright (c) Microsoft. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project.
+ */
+import { Db } from 'mongodb'
+
+module.exports = {
+	async up(db: Db) {
+		await db.collection('user_tokens').createIndex([['created', 1]])
+	},
+
+	async down(db: Db) {
+		db.collection('user_tokens').dropIndex('created_1')
+	}
+}


### PR DESCRIPTION
We order tokens  by creation date to determine which to expire. This is supported natively in MongoDB, but in Mongo-flavored CosmosDB, this requires an index to be present.