### PR TITLE
API Streamlining

### DIFF
--- a/packages/api/src/components/AppBuilder.ts
+++ b/packages/api/src/components/AppBuilder.ts
@@ -23,19 +23,19 @@ const appLogger = createLogger('app', true)
 const wsLogger = createLogger('sockets')
 
 export class AppBuilder {
-	#startupPromise: Promise<void>
-	#appContext: BuiltAppContext | undefined
-	#subscriptionServer: SubscriptionServer | undefined
+	private readonly startupPromise: Promise<void>
+	private _appContext: BuiltAppContext | undefined
+	private _subscriptionServer: SubscriptionServer | undefined
 
 	public constructor(contextProvider: AsyncProvider<BuiltAppContext>) {
-		this.#startupPromise = this.composeApplication(contextProvider)
+		this.startupPromise = this.composeApplication(contextProvider)
 	}
 
 	private get appContext(): BuiltAppContext {
-		if (this.#appContext == null) {
+		if (this._appContext == null) {
 			throw new Error('appContext has not been initalized')
 		}
-		return this.#appContext
+		return this._appContext
 	}
 
 	private get config(): Configuration {
@@ -43,14 +43,14 @@ export class AppBuilder {
 	}
 
 	private get subscriptionServer(): SubscriptionServer {
-		if (!this.#subscriptionServer) {
+		if (!this._subscriptionServer) {
 			throw new Error('subscriptionServer has not been defined')
 		}
-		return this.#subscriptionServer
+		return this._subscriptionServer
 	}
 
 	private async composeApplication(contextProvider: AsyncProvider<BuiltAppContext>): Promise<void> {
-		this.#appContext = await contextProvider.get()
+		this._appContext = await contextProvider.get()
 		if (this.config.telemetryKey != null) {
 			setupAI(this.config.telemetryKey).start()
 		}
@@ -131,7 +131,7 @@ export class AppBuilder {
 			},
 			{ server, path }
 		)
-		this.#subscriptionServer = result
+		this._subscriptionServer = result
 		return result
 	}
 
@@ -189,7 +189,7 @@ export class AppBuilder {
 	}
 
 	public async start(): Promise<http.Server> {
-		await this.#startupPromise
+		await this.startupPromise
 		const app = fastify()
 		const httpServer = app.server
 		const schema = createSchema()

--- a/packages/api/src/components/AppContextProvider.ts
+++ b/packages/api/src/components/AppContextProvider.ts
@@ -194,14 +194,7 @@ export class AppContextProvider implements AsyncProvider<BuiltAppContext> {
 					engagementCollection,
 					orgCollection
 				),
-				archiveContact: new ArchiveContactInteractor(
-					localization,
-					config,
-					contactCollection,
-					tagCollection,
-					engagementCollection,
-					orgCollection
-				),
+				archiveContact: new ArchiveContactInteractor(localization, config, contactCollection),
 				createService: new CreateServiceInteractor(localization, serviceCollection),
 				updateService: new UpdateServiceInteractor(localization, serviceCollection),
 				createServiceAnswers: new CreateServiceAnswersInteractor(

--- a/packages/api/src/components/AppContextProvider.ts
+++ b/packages/api/src/components/AppContextProvider.ts
@@ -76,7 +76,7 @@ export class AppContextProvider implements AsyncProvider<BuiltAppContext> {
 		const tagCollection = new TagCollection(conn.tagsCollection)
 		const serviceAnswerCollection = new ServiceAnswerCollection(conn.serviceAnswerCollection)
 		const localization = new Localization()
-		const notifier = new Notifications(config)
+		const notifier = new Notifications(config, localization)
 		const mailer = nodemailer.createTransport(
 			sgTransport({
 				auth: {

--- a/packages/api/src/components/DatabaseConnector.ts
+++ b/packages/api/src/components/DatabaseConnector.ts
@@ -6,21 +6,19 @@ import { Collection, Db, MongoClient } from 'mongodb'
 import { Configuration } from './Configuration'
 
 export class DatabaseConnector {
-	#config: Configuration
-	#client: MongoClient
-	#db: Db | undefined
+	private readonly _client: MongoClient
+	private _db: Db | undefined
 
-	public constructor(config: Configuration) {
-		this.#config = config
-		this.#client = new MongoClient(this.#config.dbConnectionString, {
+	public constructor(private readonly config: Configuration) {
+		this._client = new MongoClient(this.config.dbConnectionString, {
 			useUnifiedTopology: true
 		})
 	}
 
 	public async connect(): Promise<void> {
-		const dbName = this.#config.dbDatabase
-		const client = this.#client
-		this.#db = await new Promise<Db>((resolve, reject) => {
+		const dbName = this.config.dbDatabase
+		const client = this.client
+		this._db = await new Promise<Db>((resolve, reject) => {
 			client.connect((err) => {
 				if (err) {
 					reject(err)
@@ -32,41 +30,41 @@ export class DatabaseConnector {
 	}
 
 	public get client(): MongoClient {
-		return this.#client
+		return this._client
 	}
 
 	public get db(): Db {
-		if (!this.#db) {
+		if (!this._db) {
 			throw new Error('database is not initialized')
 		}
-		return this.#db
+		return this._db
 	}
 
 	public get usersCollection(): Collection {
-		return this.db.collection(this.#config.dbUsersCollection)
+		return this.db.collection(this.config.dbUsersCollection)
 	}
 
 	public get userTokensCollection(): Collection {
-		return this.db.collection(this.#config.dbUserTokensCollection)
+		return this.db.collection(this.config.dbUserTokensCollection)
 	}
 
 	public get orgsCollection(): Collection {
-		return this.db.collection(this.#config.dbOrganizationsCollection)
+		return this.db.collection(this.config.dbOrganizationsCollection)
 	}
 
 	public get contactsCollection(): Collection {
-		return this.db.collection(this.#config.dbContactsCollection)
+		return this.db.collection(this.config.dbContactsCollection)
 	}
 	public get engagementsCollection(): Collection {
-		return this.db.collection(this.#config.dbEngagementsCollection)
+		return this.db.collection(this.config.dbEngagementsCollection)
 	}
 	public get tagsCollection(): Collection {
-		return this.db.collection(this.#config.dbTagsCollection)
+		return this.db.collection(this.config.dbTagsCollection)
 	}
 	public get servicesCollection(): Collection {
-		return this.db.collection(this.#config.dbServicesCollection)
+		return this.db.collection(this.config.dbServicesCollection)
 	}
 	public get serviceAnswerCollection(): Collection {
-		return this.db.collection(this.#config.dbServiceAnswerCollection)
+		return this.db.collection(this.config.dbServiceAnswerCollection)
 	}
 }

--- a/packages/api/src/components/Localization.ts
+++ b/packages/api/src/components/Localization.ts
@@ -11,16 +11,16 @@ const logger = createLogger('localization')
  * Server Localization
  */
 export class Localization {
-	#i18nProvider: I18n
+	private readonly i18nProvider: I18n
 
 	/**
 	 *
 	 * @param i18nProvider The i18n provider
 	 */
 	public constructor() {
-		this.#i18nProvider = new I18n()
+		this.i18nProvider = new I18n()
 
-		this.#i18nProvider.configure({
+		this.i18nProvider.configure({
 			defaultLocale: 'en-US',
 
 			// will return translation from defaultLocale in case current locale doesn't provide it
@@ -52,7 +52,7 @@ export class Localization {
 	 */
 
 	public getLocales(): Array<string> {
-		return this.#i18nProvider.getLocales()
+		return this.i18nProvider.getLocales()
 	}
 
 	/**
@@ -61,7 +61,7 @@ export class Localization {
 	 */
 
 	public setLocale(locale: string): void {
-		this.#i18nProvider.setLocale(locale)
+		this.i18nProvider.setLocale(locale)
 	}
 
 	/**
@@ -72,7 +72,7 @@ export class Localization {
 	 */
 
 	public t(phrase: string, args?: any): string {
-		const result = this.#i18nProvider.__(phrase, args)
+		const result = this.i18nProvider.__(phrase, args)
 		if (!result) {
 			logger(new Error('no localization found for phrase ' + phrase))
 		}
@@ -87,7 +87,7 @@ export class Localization {
 	 */
 
 	public tn(phrase: string, count: number): string {
-		const result = this.#i18nProvider.__n(phrase, count)
+		const result = this.i18nProvider.__n(phrase, count)
 		if (!result) {
 			logger(new Error('no localization found for phrase ' + phrase))
 		}

--- a/packages/api/src/components/Notifications.ts
+++ b/packages/api/src/components/Notifications.ts
@@ -23,13 +23,11 @@ export interface NotificationOptions {
 }
 
 export class Notifications {
-	#config: Configuration
-	#fbAdmin: fbApp.App | null
+	private readonly fbAdmin: fbApp.App | null
 
 	public constructor(config: Configuration) {
-		this.#config = config
 		const isEnabled = Boolean(config.firebaseCredentials?.private_key)
-		this.#fbAdmin = isEnabled
+		this.fbAdmin = isEnabled
 			? fbInitializeApp({
 					credential: fbCredential.cert(config.firebaseCredentials as FBServiceAccount)
 			  })
@@ -43,8 +41,8 @@ export class Notifications {
 	public async sendMessage(
 		messageOptions: MessageOptions
 	): Promise<fbMessaging.MessagingDevicesResponse | null> {
-		if (this.#fbAdmin) {
-			const sendResult = await this.#fbAdmin!.messaging().sendToDevice(messageOptions.token, {
+		if (this.fbAdmin) {
+			const sendResult = await this.fbAdmin!.messaging().sendToDevice(messageOptions.token, {
 				notification: messageOptions.notification
 			} as fbMessaging.MessagingPayload)
 
@@ -60,7 +58,7 @@ export class Notifications {
 	public async assignedRequest(
 		fcmToken: string
 	): Promise<fbMessaging.MessagingDevicesResponse | null> {
-		if (this.#fbAdmin) {
+		if (this.fbAdmin) {
 			const sendResult = await this.sendMessage({
 				token: fcmToken,
 				notification: {

--- a/packages/api/src/components/Notifications.ts
+++ b/packages/api/src/components/Notifications.ts
@@ -10,6 +10,7 @@ import {
 	messaging as fbMessaging,
 	app as fbApp
 } from 'firebase-admin'
+import { Localization } from '~components'
 
 export interface MessageOptions {
 	token: string
@@ -25,7 +26,7 @@ export interface NotificationOptions {
 export class Notifications {
 	private readonly fbAdmin: fbApp.App | null
 
-	public constructor(config: Configuration) {
+	public constructor(config: Configuration, private readonly localization: Localization) {
 		const isEnabled = Boolean(config.firebaseCredentials?.private_key)
 		this.fbAdmin = isEnabled
 			? fbInitializeApp({
@@ -62,8 +63,8 @@ export class Notifications {
 			const sendResult = await this.sendMessage({
 				token: fcmToken,
 				notification: {
-					title: 'A client needs your help!',
-					body: 'Go to the dashboard to view this request'
+					title: this.localization.t('mutation.notifier.assignedRequestTitle'),
+					body: this.localization.t('mutation.notifier.assignedRequestBody')
 				}
 			})
 

--- a/packages/api/src/components/Publisher.ts
+++ b/packages/api/src/components/Publisher.ts
@@ -18,7 +18,7 @@ export class Publisher {
 		private readonly localization: Localization
 	) {}
 
-	public publishMention(userId: string, mention: Mention) {
+	public publishMention(userId: string, mention: Mention): Promise<void> {
 		return this.pubsub.publish(mentionChannel(userId), {
 			action: 'CREATED',
 			message: this.localization.t('mutation.addEngagementAction.success'),
@@ -27,7 +27,7 @@ export class Publisher {
 		})
 	}
 
-	public publishEngagementAssigned(orgId: string, engagement: Engagement) {
+	public publishEngagementAssigned(orgId: string, engagement: Engagement): Promise<void> {
 		return this.pubsub.publish(engagementChannel(orgId), {
 			action: 'UPDATE',
 			message: this.localization.t('mutation.assignEngagement.success'),
@@ -36,7 +36,7 @@ export class Publisher {
 		})
 	}
 
-	public publishEngagementCompleted(orgId: string, engagement: Engagement) {
+	public publishEngagementCompleted(orgId: string, engagement: Engagement): Promise<void> {
 		return this.pubsub.publish(engagementChannel(orgId), {
 			action: 'COMPLETED',
 			message: this.localization.t('mutation.completeEngagement.success'),
@@ -45,7 +45,7 @@ export class Publisher {
 		})
 	}
 
-	public publishEngagementCreated(orgId: string, engagement: Engagement) {
+	public publishEngagementCreated(orgId: string, engagement: Engagement): Promise<void> {
 		return this.pubsub.publish(engagementChannel(orgId), {
 			action: 'CREATED',
 			message: this.localization.t('mutation.createEngagement.success'),
@@ -54,7 +54,7 @@ export class Publisher {
 		})
 	}
 
-	public publishEngagementClosed(orgId: string, engagement: Engagement) {
+	public publishEngagementClosed(orgId: string, engagement: Engagement): Promise<void> {
 		return this.pubsub.publish(engagementChannel(orgId), {
 			action: EngagementStatus.Closed,
 			message: this.localization.t('mutation.setEngagementStatus.success'),
@@ -63,7 +63,7 @@ export class Publisher {
 		})
 	}
 
-	public publishEngagementUpdated(orgId: string, engagement: Engagement) {
+	public publishEngagementUpdated(orgId: string, engagement: Engagement): Promise<void> {
 		return this.pubsub.publish(engagementChannel(orgId), {
 			action: 'UPDATED',
 			message: this.localization.t('mutation.updateEngagement.success'),

--- a/packages/api/src/components/Publisher.ts
+++ b/packages/api/src/components/Publisher.ts
@@ -1,0 +1,77 @@
+/*!
+ * Copyright (c) Microsoft. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project.
+ */
+
+import {
+	Engagement,
+	EngagementStatus,
+	Mention,
+	StatusType
+} from '@cbosuite/schema/dist/provider-types'
+import { PubSub } from 'graphql-subscriptions'
+import { Localization } from '~components'
+
+export class Publisher {
+	public constructor(
+		private readonly pubsub: PubSub,
+		private readonly localization: Localization
+	) {}
+
+	public publishMention(userId: string, mention: Mention) {
+		return this.pubsub.publish(mentionChannel(userId), {
+			action: 'CREATED',
+			message: this.localization.t('mutation.addEngagementAction.success'),
+			mention,
+			status: StatusType.Success
+		})
+	}
+
+	public publishEngagementAssigned(orgId: string, engagement: Engagement) {
+		return this.pubsub.publish(engagementChannel(orgId), {
+			action: 'UPDATE',
+			message: this.localization.t('mutation.assignEngagement.success'),
+			engagement,
+			status: StatusType.Success
+		})
+	}
+
+	public publishEngagementCompleted(orgId: string, engagement: Engagement) {
+		return this.pubsub.publish(engagementChannel(orgId), {
+			action: 'COMPLETED',
+			message: this.localization.t('mutation.completeEngagement.success'),
+			engagement,
+			status: StatusType.Success
+		})
+	}
+
+	public publishEngagementCreated(orgId: string, engagement: Engagement) {
+		return this.pubsub.publish(engagementChannel(orgId), {
+			action: 'CREATED',
+			message: this.localization.t('mutation.createEngagement.success'),
+			engagement,
+			status: StatusType.Success
+		})
+	}
+
+	public publishEngagementClosed(orgId: string, engagement: Engagement) {
+		return this.pubsub.publish(engagementChannel(orgId), {
+			action: EngagementStatus.Closed,
+			message: this.localization.t('mutation.setEngagementStatus.success'),
+			engagement,
+			status: StatusType.Success
+		})
+	}
+
+	public publishEngagementUpdated(orgId: string, engagement: Engagement) {
+		return this.pubsub.publish(engagementChannel(orgId), {
+			action: 'UPDATED',
+			message: this.localization.t('mutation.updateEngagement.success'),
+			engagement,
+			status: StatusType.Success
+		})
+	}
+}
+
+const mentionChannel = (userId: string): string => `USER_MENTION_UPDATES_${userId}`
+const engagementChannel = (orgId: string): string => `ORG_ENGAGEMENT_UPDATES_${orgId}`

--- a/packages/api/src/dto/createGQLEngagement.ts
+++ b/packages/api/src/dto/createGQLEngagement.ts
@@ -22,7 +22,6 @@ export function createGQLEngagement(engagement: DbEngagement): Engagement {
 		user: engagement.user_id as any,
 		contacts: engagement.contacts as any,
 		// These are just IDs, resolve into tag objects in the resolve stack
-		// TODO: change any to proper tags type
 		tags: (engagement.tags as any) ?? []
 	}
 }

--- a/packages/api/src/interactors/AddEngagementInteractor.ts
+++ b/packages/api/src/interactors/AddEngagementInteractor.ts
@@ -13,6 +13,7 @@ import { DbAction, EngagementCollection, UserCollection } from '~db'
 import { createDBAction, createDBMention, createGQLEngagement, createGQLMention } from '~dto'
 import { Interactor, RequestContext } from '~types'
 import { sortByDate } from '~utils'
+import { FailedEngagementResponse, SuccessEngagementResponse } from '~utils/response'
 
 export class AddEngagementInteractor
 	implements Interactor<EngagementActionInput, EngagementResponse>
@@ -48,11 +49,9 @@ export class AddEngagementInteractor
 
 		// If not found
 		if (!engagement.item) {
-			return {
-				engagement: null,
-				message: this.#localization.t('mutation.addEngagementAction.requestNotFound'),
-				status: StatusType.Failed
-			}
+			return new FailedEngagementResponse(
+				this.#localization.t('mutation.addEngagementAction.requestNotFound')
+			)
 		}
 
 		// Set actions
@@ -84,10 +83,9 @@ export class AddEngagementInteractor
 		await this.#engagements.updateItem({ id }, { $push: { actions: nextAction } })
 		engagement.item.actions = [...engagement.item.actions, nextAction].sort(sortByDate)
 
-		return {
-			engagement: createGQLEngagement(engagement.item),
-			message: this.#localization.t('mutation.addEngagementAction.success'),
-			status: StatusType.Success
-		}
+		return new SuccessEngagementResponse(
+			this.#localization.t('mutation.addEngagementAction.success'),
+			createGQLEngagement(engagement.item)
+		)
 	}
 }

--- a/packages/api/src/interactors/AddEngagementInteractor.ts
+++ b/packages/api/src/interactors/AddEngagementInteractor.ts
@@ -13,7 +13,7 @@ import { DbAction, EngagementCollection, UserCollection } from '~db'
 import { createDBAction, createDBMention, createGQLEngagement, createGQLMention } from '~dto'
 import { Interactor, RequestContext } from '~types'
 import { sortByDate } from '~utils'
-import { FailedEngagementResponse, SuccessEngagementResponse } from '~utils/response'
+import { FailedResponse, SuccessEngagementResponse } from '~utils/response'
 
 export class AddEngagementInteractor
 	implements Interactor<EngagementActionInput, EngagementResponse>
@@ -49,7 +49,7 @@ export class AddEngagementInteractor
 
 		// If not found
 		if (!engagement.item) {
-			return new FailedEngagementResponse(
+			return new FailedResponse(
 				this.#localization.t('mutation.addEngagementAction.requestNotFound')
 			)
 		}

--- a/packages/api/src/interactors/AddEngagementInteractor.ts
+++ b/packages/api/src/interactors/AddEngagementInteractor.ts
@@ -2,13 +2,9 @@
  * Copyright (c) Microsoft. All rights reserved.
  * Licensed under the MIT license. See LICENSE file in the project.
  */
-import {
-	EngagementActionInput,
-	EngagementResponse,
-	StatusType
-} from '@cbosuite/schema/dist/provider-types'
-import { PubSub } from 'graphql-subscriptions'
+import { EngagementActionInput, EngagementResponse } from '@cbosuite/schema/dist/provider-types'
 import { Localization } from '~components'
+import { Publisher } from '~components/Publisher'
 import { DbAction, EngagementCollection, UserCollection } from '~db'
 import { createDBAction, createDBMention, createGQLEngagement, createGQLMention } from '~dto'
 import { Interactor, RequestContext } from '~types'
@@ -18,22 +14,12 @@ import { FailedResponse, SuccessEngagementResponse } from '~utils/response'
 export class AddEngagementInteractor
 	implements Interactor<EngagementActionInput, EngagementResponse>
 {
-	#localization: Localization
-	#engagements: EngagementCollection
-	#users: UserCollection
-	#pubsub: PubSub
-
 	public constructor(
-		localization: Localization,
-		engagements: EngagementCollection,
-		users: UserCollection,
-		pubsub: PubSub
-	) {
-		this.#localization = localization
-		this.#engagements = engagements
-		this.#users = users
-		this.#pubsub = pubsub
-	}
+		private readonly localization: Localization,
+		private readonly engagements: EngagementCollection,
+		private readonly users: UserCollection,
+		private readonly publisher: Publisher
+	) {}
 
 	public async execute(
 		body: EngagementActionInput,
@@ -41,17 +27,15 @@ export class AddEngagementInteractor
 	): Promise<EngagementResponse> {
 		const { engId: id, action } = body
 		if (!action.userId) {
-			throw new Error(this.#localization.t('mutation.addEngagementAction.userIdRequired'))
+			throw new Error(this.localization.t('mutation.addEngagementAction.userIdRequired'))
 		}
 
 		//  Get engagement from db
-		const engagement = await this.#engagements.itemById(id)
+		const engagement = await this.engagements.itemById(id)
 
 		// If not found
 		if (!engagement.item) {
-			return new FailedResponse(
-				this.#localization.t('mutation.addEngagementAction.requestNotFound')
-			)
+			return new FailedResponse(this.localization.t('mutation.addEngagementAction.requestNotFound'))
 		}
 
 		// Set actions
@@ -59,7 +43,7 @@ export class AddEngagementInteractor
 
 		// Add a mention for the tagged user
 		if (action.taggedUserId) {
-			const taggedUser = await this.#users.itemById(action.taggedUserId)
+			const taggedUser = await this.users.itemById(action.taggedUserId)
 
 			if (taggedUser.item) {
 				const dbMention = createDBMention(
@@ -68,23 +52,16 @@ export class AddEngagementInteractor
 					nextAction.date,
 					action.comment
 				)
-				this.#users.updateItem({ id: taggedUser.item.id }, { $push: { mentions: dbMention } })
-
-				// Push to subscribed user
-				await this.#pubsub.publish(`USER_MENTION_UPDATES_${taggedUser.item.id}`, {
-					action: 'CREATED',
-					message: this.#localization.t('mutation.addEngagementAction.success'),
-					mention: createGQLMention(dbMention),
-					status: StatusType.Success
-				})
+				this.users.updateItem({ id: taggedUser.item.id }, { $push: { mentions: dbMention } })
+				await this.publisher.publishMention(taggedUser.item.id, createGQLMention(dbMention))
 			}
 		}
 
-		await this.#engagements.updateItem({ id }, { $push: { actions: nextAction } })
+		await this.engagements.updateItem({ id }, { $push: { actions: nextAction } })
 		engagement.item.actions = [...engagement.item.actions, nextAction].sort(sortByDate)
 
 		return new SuccessEngagementResponse(
-			this.#localization.t('mutation.addEngagementAction.success'),
+			this.localization.t('mutation.addEngagementAction.success'),
 			createGQLEngagement(engagement.item)
 		)
 	}

--- a/packages/api/src/interactors/ArchiveContactInteractor.ts
+++ b/packages/api/src/interactors/ArchiveContactInteractor.ts
@@ -3,32 +3,24 @@
  * Licensed under the MIT license. See LICENSE file in the project.
  */
 import { ContactIdInput, VoidResponse, ContactStatus } from '@cbosuite/schema/dist/provider-types'
-import { Configuration, Localization } from '~components'
+import { Localization } from '~components'
 import { ContactCollection } from '~db'
 import { Interactor } from '~types'
 import { FailedResponse, SuccessVoidResponse } from '~utils/response'
 
 export class ArchiveContactInteractor implements Interactor<ContactIdInput, VoidResponse> {
-	#localization: Localization
-	#contacts: ContactCollection
-
 	public constructor(
-		localization: Localization,
-		config: Configuration,
-		contacts: ContactCollection
-	) {
-		this.#localization = localization
-		this.#contacts = contacts
-		this.#contacts = contacts
-	}
+		private readonly localization: Localization,
+		private readonly contacts: ContactCollection
+	) {}
 
 	public async execute({ contactId }: ContactIdInput): Promise<VoidResponse> {
 		if (!contactId) {
-			return new FailedResponse(this.#localization.t('mutation.updateContact.contactIdRequired'))
+			return new FailedResponse(this.localization.t('mutation.updateContact.contactIdRequired'))
 		}
 
-		await this.#contacts.updateItem({ id: contactId }, { $set: { status: ContactStatus.Archived } })
+		await this.contacts.updateItem({ id: contactId }, { $set: { status: ContactStatus.Archived } })
 
-		return new SuccessVoidResponse(this.#localization.t('mutation.updateContact.success'))
+		return new SuccessVoidResponse(this.localization.t('mutation.updateContact.success'))
 	}
 }

--- a/packages/api/src/interactors/ArchiveContactInteractor.ts
+++ b/packages/api/src/interactors/ArchiveContactInteractor.ts
@@ -6,7 +6,7 @@ import { ContactIdInput, VoidResponse, ContactStatus } from '@cbosuite/schema/di
 import { Configuration, Localization } from '~components'
 import { ContactCollection } from '~db'
 import { Interactor } from '~types'
-import { FailedVoidResponse, SuccessVoidResponse } from '~utils/response'
+import { FailedResponse, SuccessVoidResponse } from '~utils/response'
 
 export class ArchiveContactInteractor implements Interactor<ContactIdInput, VoidResponse> {
 	#localization: Localization
@@ -24,9 +24,7 @@ export class ArchiveContactInteractor implements Interactor<ContactIdInput, Void
 
 	public async execute({ contactId }: ContactIdInput): Promise<VoidResponse> {
 		if (!contactId) {
-			return new FailedVoidResponse(
-				this.#localization.t('mutation.updateContact.contactIdRequired')
-			)
+			return new FailedResponse(this.#localization.t('mutation.updateContact.contactIdRequired'))
 		}
 
 		await this.#contacts.updateItem({ id: contactId }, { $set: { status: ContactStatus.Archived } })

--- a/packages/api/src/interactors/ArchiveContactInteractor.ts
+++ b/packages/api/src/interactors/ArchiveContactInteractor.ts
@@ -2,54 +2,35 @@
  * Copyright (c) Microsoft. All rights reserved.
  * Licensed under the MIT license. See LICENSE file in the project.
  */
-import {
-	ContactIdInput,
-	VoidResponse,
-	StatusType,
-	ContactStatus
-} from '@cbosuite/schema/dist/provider-types'
+import { ContactIdInput, VoidResponse, ContactStatus } from '@cbosuite/schema/dist/provider-types'
 import { Configuration, Localization } from '~components'
-import { ContactCollection, TagCollection, EngagementCollection, OrganizationCollection } from '~db'
+import { ContactCollection } from '~db'
 import { Interactor } from '~types'
+import { FailedVoidResponse, SuccessVoidResponse } from '~utils/response'
 
 export class ArchiveContactInteractor implements Interactor<ContactIdInput, VoidResponse> {
 	#localization: Localization
-	#config: Configuration
 	#contacts: ContactCollection
-	#tags: TagCollection
-	#engagements: EngagementCollection
-	#orgs: OrganizationCollection
 
 	public constructor(
 		localization: Localization,
 		config: Configuration,
-		contacts: ContactCollection,
-		tags: TagCollection,
-		engagements: EngagementCollection,
-		orgs: OrganizationCollection
+		contacts: ContactCollection
 	) {
 		this.#localization = localization
-		this.#config = config
 		this.#contacts = contacts
 		this.#contacts = contacts
-		this.#engagements = engagements
-		this.#orgs = orgs
-		this.#tags = tags
 	}
 
 	public async execute({ contactId }: ContactIdInput): Promise<VoidResponse> {
 		if (!contactId) {
-			return {
-				message: this.#localization.t('mutation.updateContact.contactIdRequired'),
-				status: StatusType.Failed
-			}
+			return new FailedVoidResponse(
+				this.#localization.t('mutation.updateContact.contactIdRequired')
+			)
 		}
 
 		await this.#contacts.updateItem({ id: contactId }, { $set: { status: ContactStatus.Archived } })
 
-		return {
-			message: this.#localization.t('mutation.updateContact.success'),
-			status: StatusType.Success
-		}
+		return new SuccessVoidResponse(this.#localization.t('mutation.updateContact.success'))
 	}
 }

--- a/packages/api/src/interactors/AssignEngagementInteractor.ts
+++ b/packages/api/src/interactors/AssignEngagementInteractor.ts
@@ -61,13 +61,7 @@ export class AssignEngagementInteractor
 			// Send the user a push notification
 			if (user.item.fcm_token) {
 				logger('attempting to send message to ', user.item.fcm_token)
-				this.notifier.sendMessage({
-					token: user.item.fcm_token,
-					notification: {
-						title: 'A client needs your help!',
-						body: 'Go to the dashboard to view this request'
-					}
-				})
+				this.notifier.assignedRequest(user.item.fcm_token)
 			}
 		}
 

--- a/packages/api/src/interactors/AssignEngagementInteractor.ts
+++ b/packages/api/src/interactors/AssignEngagementInteractor.ts
@@ -13,6 +13,7 @@ import { DbAction, EngagementCollection, UserCollection } from '~db'
 import { createDBAction, createGQLEngagement, createGQLUser } from '~dto'
 import { Interactor, RequestContext } from '~types'
 import { sortByDate, createLogger } from '~utils'
+import { FailedEngagementResponse, SuccessEngagementResponse } from '~utils/response'
 
 const logger = createLogger('interactors:assign-engagement', true)
 
@@ -49,18 +50,14 @@ export class AssignEngagementInteractor
 			this.#users.itemById(userId)
 		])
 		if (!user.item) {
-			return {
-				engagement: null,
-				message: this.#localization.t('mutation.assignEngagement.userNotFound'),
-				status: StatusType.Failed
-			}
+			return new FailedEngagementResponse(
+				this.#localization.t('mutation.assignEngagement.userNotFound')
+			)
 		}
 		if (!engagement.item) {
-			return {
-				engagement: null,
-				message: this.#localization.t('mutation.assignEngagement.requestNotFound'),
-				status: StatusType.Failed
-			}
+			return new FailedEngagementResponse(
+				this.#localization.t('mutation.assignEngagement.requestNotFound')
+			)
 		}
 
 		// Set assignee
@@ -123,10 +120,9 @@ export class AssignEngagementInteractor
 		})
 
 		// Return updated engagement
-		return {
-			engagement: updatedEngagement,
-			message: this.#localization.t('mutation.assignEngagement.success'),
-			status: StatusType.Success
-		}
+		return new SuccessEngagementResponse(
+			this.#localization.t('mutation.assignEngagement.success'),
+			updatedEngagement
+		)
 	}
 }

--- a/packages/api/src/interactors/AssignEngagementInteractor.ts
+++ b/packages/api/src/interactors/AssignEngagementInteractor.ts
@@ -13,7 +13,7 @@ import { DbAction, EngagementCollection, UserCollection } from '~db'
 import { createDBAction, createGQLEngagement, createGQLUser } from '~dto'
 import { Interactor, RequestContext } from '~types'
 import { sortByDate, createLogger } from '~utils'
-import { FailedEngagementResponse, SuccessEngagementResponse } from '~utils/response'
+import { FailedResponse, SuccessEngagementResponse } from '~utils/response'
 
 const logger = createLogger('interactors:assign-engagement', true)
 
@@ -50,14 +50,10 @@ export class AssignEngagementInteractor
 			this.#users.itemById(userId)
 		])
 		if (!user.item) {
-			return new FailedEngagementResponse(
-				this.#localization.t('mutation.assignEngagement.userNotFound')
-			)
+			return new FailedResponse(this.#localization.t('mutation.assignEngagement.userNotFound'))
 		}
 		if (!engagement.item) {
-			return new FailedEngagementResponse(
-				this.#localization.t('mutation.assignEngagement.requestNotFound')
-			)
+			return new FailedResponse(this.#localization.t('mutation.assignEngagement.requestNotFound'))
 		}
 
 		// Set assignee

--- a/packages/api/src/interactors/AuthenticateInteractor.ts
+++ b/packages/api/src/interactors/AuthenticateInteractor.ts
@@ -12,28 +12,25 @@ import { FailedResponse, SuccessAuthenticationResponse } from '~utils/response'
 export class AuthenticateInteractor
 	implements Interactor<AuthenticationInput, AuthenticationResponse>
 {
-	#authenticator: Authenticator
-	#localization: Localization
-
-	public constructor(authenticator: Authenticator, localization: Localization) {
-		this.#authenticator = authenticator
-		this.#localization = localization
-	}
+	public constructor(
+		private readonly authenticator: Authenticator,
+		private readonly localization: Localization
+	) {}
 
 	public async execute({
 		username,
 		password
 	}: AuthenticationInput): Promise<AuthenticationResponse> {
 		if (!isEmpty(username) && !isEmpty(password)) {
-			const { user, token } = await this.#authenticator.authenticateBasic(username, password)
+			const { user, token } = await this.authenticator.authenticateBasic(username, password)
 			if (user) {
 				return new SuccessAuthenticationResponse(
-					this.#localization.t('mutation.authenticate.success'),
+					this.localization.t('mutation.authenticate.success'),
 					createGQLUser(user),
 					token
 				)
 			}
 		}
-		return new FailedResponse(this.#localization.t('mutation.authenticate.failed'))
+		return new FailedResponse(this.localization.t('mutation.authenticate.failed'))
 	}
 }

--- a/packages/api/src/interactors/AuthenticateInteractor.ts
+++ b/packages/api/src/interactors/AuthenticateInteractor.ts
@@ -2,15 +2,12 @@
  * Copyright (c) Microsoft. All rights reserved.
  * Licensed under the MIT license. See LICENSE file in the project.
  */
-import {
-	AuthenticationInput,
-	AuthenticationResponse,
-	StatusType
-} from '@cbosuite/schema/dist/provider-types'
+import { AuthenticationInput, AuthenticationResponse } from '@cbosuite/schema/dist/provider-types'
 import isEmpty from 'lodash/isEmpty'
 import { Authenticator, Localization } from '~components'
 import { createGQLUser } from '~dto'
 import { Interactor } from '~types'
+import { FailedResponse, SuccessAuthenticationResponse } from '~utils/response'
 
 export class AuthenticateInteractor
 	implements Interactor<AuthenticationInput, AuthenticationResponse>
@@ -30,18 +27,13 @@ export class AuthenticateInteractor
 		if (!isEmpty(username) && !isEmpty(password)) {
 			const { user, token } = await this.#authenticator.authenticateBasic(username, password)
 			if (user) {
-				return {
-					accessToken: token,
-					user: createGQLUser(user),
-					message: this.#localization.t('mutation.authenticate.success'),
-					status: StatusType.Success
-				}
+				return new SuccessAuthenticationResponse(
+					this.#localization.t('mutation.authenticate.success'),
+					createGQLUser(user),
+					token
+				)
 			}
 		}
-		return {
-			user: null,
-			message: this.#localization.t('mutation.authenticate.failed'),
-			status: StatusType.Failed
-		}
+		return new FailedResponse(this.#localization.t('mutation.authenticate.failed'))
 	}
 }

--- a/packages/api/src/interactors/ChangeUserPasswordInteractor.ts
+++ b/packages/api/src/interactors/ChangeUserPasswordInteractor.ts
@@ -9,10 +9,7 @@ import {
 import { Authenticator, Localization } from '~components'
 import { UserCollection } from '~db'
 import { Interactor } from '~types'
-import {
-	FailedForgotUserPasswordResponse,
-	SuccessForgotUserPasswordResponse
-} from '~utils/response'
+import { FailedResponse, SuccessForgotUserPasswordResponse } from '~utils/response'
 
 export class ChangeUserPasswordInteractor
 	implements Interactor<ChangeUserPasswordInput, ForgotUserPasswordResponse>
@@ -36,16 +33,12 @@ export class ChangeUserPasswordInteractor
 		const user = await this.#users.item({ email })
 
 		if (!user.item) {
-			return new FailedForgotUserPasswordResponse(
-				this.#localization.t('mutation.forgotUserPassword.userNotFound')
-			)
+			return new FailedResponse(this.#localization.t('mutation.forgotUserPassword.userNotFound'))
 		}
 		const response = await this.#authenticator.setPassword(user.item, newPassword)
 
 		if (!response) {
-			return new FailedForgotUserPasswordResponse(
-				this.#localization.t('mutation.forgotUserPassword.resetError')
-			)
+			return new FailedResponse(this.#localization.t('mutation.forgotUserPassword.resetError'))
 		}
 
 		await this.#users.updateItem({ email: email }, { $unset: { forgot_password_token: '' } })

--- a/packages/api/src/interactors/ChangeUserPasswordInteractor.ts
+++ b/packages/api/src/interactors/ChangeUserPasswordInteractor.ts
@@ -2,49 +2,36 @@
  * Copyright (c) Microsoft. All rights reserved.
  * Licensed under the MIT license. See LICENSE file in the project.
  */
-import {
-	ChangeUserPasswordInput,
-	ForgotUserPasswordResponse
-} from '@cbosuite/schema/dist/provider-types'
+import { ChangeUserPasswordInput, VoidResponse } from '@cbosuite/schema/dist/provider-types'
 import { Authenticator, Localization } from '~components'
 import { UserCollection } from '~db'
 import { Interactor } from '~types'
-import { FailedResponse, SuccessForgotUserPasswordResponse } from '~utils/response'
+import { FailedResponse, SuccessVoidResponse } from '~utils/response'
 
 export class ChangeUserPasswordInteractor
-	implements Interactor<ChangeUserPasswordInput, ForgotUserPasswordResponse>
+	implements Interactor<ChangeUserPasswordInput, VoidResponse>
 {
-	#localization: Localization
-	#users: UserCollection
-	#authenticator: Authenticator
-
 	public constructor(
-		localization: Localization,
-		authenticator: Authenticator,
-		users: UserCollection
-	) {
-		this.#localization = localization
-		this.#authenticator = authenticator
-		this.#users = users
-	}
+		private readonly localization: Localization,
+		private readonly authenticator: Authenticator,
+		private readonly users: UserCollection
+	) {}
 
-	public async execute(body: ChangeUserPasswordInput): Promise<ForgotUserPasswordResponse> {
+	public async execute(body: ChangeUserPasswordInput): Promise<VoidResponse> {
 		const { email, newPassword } = body
-		const user = await this.#users.item({ email })
+		const user = await this.users.item({ email })
 
 		if (!user.item) {
-			return new FailedResponse(this.#localization.t('mutation.forgotUserPassword.userNotFound'))
+			return new FailedResponse(this.localization.t('mutation.forgotUserPassword.userNotFound'))
 		}
-		const response = await this.#authenticator.setPassword(user.item, newPassword)
+		const response = await this.authenticator.setPassword(user.item, newPassword)
 
 		if (!response) {
-			return new FailedResponse(this.#localization.t('mutation.forgotUserPassword.resetError'))
+			return new FailedResponse(this.localization.t('mutation.forgotUserPassword.resetError'))
 		}
 
-		await this.#users.updateItem({ email: email }, { $unset: { forgot_password_token: '' } })
+		await this.users.updateItem({ email: email }, { $unset: { forgot_password_token: '' } })
 
-		return new SuccessForgotUserPasswordResponse(
-			this.#localization.t('mutation.forgotUserPassword.success')
-		)
+		return new SuccessVoidResponse(this.localization.t('mutation.forgotUserPassword.success'))
 	}
 }

--- a/packages/api/src/interactors/ChangeUserPasswordInteractor.ts
+++ b/packages/api/src/interactors/ChangeUserPasswordInteractor.ts
@@ -4,12 +4,15 @@
  */
 import {
 	ChangeUserPasswordInput,
-	ForgotUserPasswordResponse,
-	StatusType
+	ForgotUserPasswordResponse
 } from '@cbosuite/schema/dist/provider-types'
 import { Authenticator, Localization } from '~components'
 import { UserCollection } from '~db'
 import { Interactor } from '~types'
+import {
+	FailedForgotUserPasswordResponse,
+	SuccessForgotUserPasswordResponse
+} from '~utils/response'
 
 export class ChangeUserPasswordInteractor
 	implements Interactor<ChangeUserPasswordInput, ForgotUserPasswordResponse>
@@ -33,25 +36,22 @@ export class ChangeUserPasswordInteractor
 		const user = await this.#users.item({ email })
 
 		if (!user.item) {
-			return {
-				status: StatusType.Failed,
-				message: this.#localization.t('mutation.forgotUserPassword.userNotFound')
-			}
+			return new FailedForgotUserPasswordResponse(
+				this.#localization.t('mutation.forgotUserPassword.userNotFound')
+			)
 		}
 		const response = await this.#authenticator.setPassword(user.item, newPassword)
 
 		if (!response) {
-			return {
-				status: StatusType.Failed,
-				message: this.#localization.t('mutation.forgotUserPassword.resetError')
-			}
+			return new FailedForgotUserPasswordResponse(
+				this.#localization.t('mutation.forgotUserPassword.resetError')
+			)
 		}
 
 		await this.#users.updateItem({ email: email }, { $unset: { forgot_password_token: '' } })
 
-		return {
-			status: StatusType.Success,
-			message: this.#localization.t('mutation.forgotUserPassword.success')
-		}
+		return new SuccessForgotUserPasswordResponse(
+			this.#localization.t('mutation.forgotUserPassword.success')
+		)
 	}
 }

--- a/packages/api/src/interactors/CompleteEngagementInteractor.ts
+++ b/packages/api/src/interactors/CompleteEngagementInteractor.ts
@@ -5,11 +5,10 @@
 import {
 	EngagementIdInput,
 	EngagementResponse,
-	EngagementStatus,
-	StatusType
+	EngagementStatus
 } from '@cbosuite/schema/dist/provider-types'
-import { PubSub } from 'graphql-subscriptions'
 import { Localization } from '~components'
+import { Publisher } from '~components/Publisher'
 import { EngagementCollection } from '~db'
 import { createDBAction, createGQLEngagement } from '~dto'
 import { Interactor, RequestContext } from '~types'
@@ -19,19 +18,11 @@ import { FailedResponse, SuccessEngagementResponse } from '~utils/response'
 export class CompleteEngagementInteractor
 	implements Interactor<EngagementIdInput, EngagementResponse>
 {
-	#localization: Localization
-	#engagements: EngagementCollection
-	#pubsub: PubSub
-
 	public constructor(
-		localization: Localization,
-		engagements: EngagementCollection,
-		pubsub: PubSub
-	) {
-		this.#localization = localization
-		this.#engagements = engagements
-		this.#pubsub = pubsub
-	}
+		private readonly localization: Localization,
+		private readonly engagements: EngagementCollection,
+		private readonly publisher: Publisher
+	) {}
 
 	public async execute(
 		body: EngagementIdInput,
@@ -39,40 +30,38 @@ export class CompleteEngagementInteractor
 	): Promise<EngagementResponse> {
 		const { engId: id } = body
 		if (!identity) {
-			return new FailedResponse(this.#localization.t('mutation.completeEngagement.unauthorized'))
+			return new FailedResponse(this.localization.t('mutation.completeEngagement.unauthorized'))
 		}
 
-		const engagement = await this.#engagements.itemById(id)
+		const engagement = await this.engagements.itemById(id)
 		if (!engagement.item) {
-			return new FailedResponse(this.#localization.t('mutation.completeEngagement.requestNotFound'))
+			return new FailedResponse(this.localization.t('mutation.completeEngagement.requestNotFound'))
 		}
 
 		// Set status
-		await this.#engagements.updateItem({ id }, { $set: { status: EngagementStatus.Completed } })
+		await this.engagements.updateItem({ id }, { $set: { status: EngagementStatus.Completed } })
 		engagement.item.status = EngagementStatus.Completed
 
 		// Publish changes to websocketk connection
-		await this.#pubsub.publish(`ORG_ENGAGEMENT_UPDATES_${engagement.item.org_id}`, {
-			action: 'COMPLETED',
-			message: this.#localization.t('mutation.completeEngagement.success'),
-			engagement: createGQLEngagement(engagement.item),
-			status: StatusType.Success
-		})
+		await this.publisher.publishEngagementCompleted(
+			engagement.item.org_id,
+			createGQLEngagement(engagement.item)
+		)
 
 		// Create action
 		const currentUserId = identity.id
 		const nextAction = createDBAction({
-			comment: this.#localization.t('mutation.completeEngagement.actions.markComplete'),
+			comment: this.localization.t('mutation.completeEngagement.actions.markComplete'),
 			orgId: engagement.item.org_id,
 			userId: currentUserId,
 			taggedUserId: currentUserId
 		})
 
-		await this.#engagements.updateItem({ id }, { $push: { actions: nextAction } })
+		await this.engagements.updateItem({ id }, { $push: { actions: nextAction } })
 		engagement.item.actions = [...engagement.item.actions, nextAction].sort(sortByDate)
 
 		return new SuccessEngagementResponse(
-			this.#localization.t('mutation.completeEngagement.success'),
+			this.localization.t('mutation.completeEngagement.success'),
 			createGQLEngagement(engagement.item)
 		)
 	}

--- a/packages/api/src/interactors/CreateContactInteractor.ts
+++ b/packages/api/src/interactors/CreateContactInteractor.ts
@@ -11,34 +11,26 @@ import { Interactor } from '~types'
 import { FailedResponse, SuccessContactResponse } from '~utils/response'
 
 export class CreateContactInteractor implements Interactor<ContactInput, ContactResponse> {
-	#localization: Localization
-	#contacts: ContactCollection
-	#orgs: OrganizationCollection
-
 	public constructor(
-		localization: Localization,
-		contacts: ContactCollection,
-		orgs: OrganizationCollection
-	) {
-		this.#localization = localization
-		this.#contacts = contacts
-		this.#orgs = orgs
-	}
+		private readonly localization: Localization,
+		private readonly contacts: ContactCollection,
+		private readonly orgs: OrganizationCollection
+	) {}
 
 	public async execute(contact: ContactInput): Promise<ContactResponse> {
 		if (!contact.orgId) {
-			return new FailedResponse(this.#localization.t('mutation.createContact.orgIdRequired'))
+			return new FailedResponse(this.localization.t('mutation.createContact.orgIdRequired'))
 		}
 
 		const newContact = createDBContact(contact)
 
 		await Promise.all([
-			this.#contacts.insertItem(newContact),
-			this.#orgs.updateItem({ id: newContact.org_id }, { $push: { contacts: newContact.id } })
+			this.contacts.insertItem(newContact),
+			this.orgs.updateItem({ id: newContact.org_id }, { $push: { contacts: newContact.id } })
 		])
 
 		return new SuccessContactResponse(
-			this.#localization.t('mutation.createContact.success'),
+			this.localization.t('mutation.createContact.success'),
 			createGQLContact(newContact)
 		)
 	}

--- a/packages/api/src/interactors/CreateEngagementInteractor.ts
+++ b/packages/api/src/interactors/CreateEngagementInteractor.ts
@@ -19,6 +19,7 @@ import {
 } from '~dto'
 import { Interactor, RequestContext } from '~types'
 import { sortByDate, createLogger } from '~utils'
+import { SuccessEngagementResponse } from '~utils/response'
 
 const logger = createLogger('interactors:create-engagement', true)
 
@@ -160,10 +161,9 @@ export class CreateEngagementInteractor implements Interactor<EngagementInput, E
 		nextEngagement.actions = [...nextEngagement.actions, ...actionsToAssign].sort(sortByDate)
 
 		// Return created engagement
-		return {
-			engagement: createGQLEngagement(nextEngagement),
-			message: this.#localization.t('mutation.createEngagement.success'),
-			status: StatusType.Success
-		}
+		return new SuccessEngagementResponse(
+			this.#localization.t('mutation.createEngagement.success'),
+			createGQLEngagement(nextEngagement)
+		)
 	}
 }

--- a/packages/api/src/interactors/CreateEngagementInteractor.ts
+++ b/packages/api/src/interactors/CreateEngagementInteractor.ts
@@ -2,13 +2,9 @@
  * Copyright (c) Microsoft. All rights reserved.
  * Licensed under the MIT license. See LICENSE file in the project.
  */
-import {
-	EngagementInput,
-	EngagementResponse,
-	StatusType
-} from '@cbosuite/schema/dist/provider-types'
-import { PubSub } from 'graphql-subscriptions'
+import { EngagementInput, EngagementResponse } from '@cbosuite/schema/dist/provider-types'
 import { Localization, Notifications } from '~components'
+import { Publisher } from '~components/Publisher'
 import { DbAction, EngagementCollection, UserCollection } from '~db'
 import {
 	createDBAction,
@@ -24,25 +20,13 @@ import { SuccessEngagementResponse } from '~utils/response'
 const logger = createLogger('interactors:create-engagement', true)
 
 export class CreateEngagementInteractor implements Interactor<EngagementInput, EngagementResponse> {
-	#localization: Localization
-	#pubsub: PubSub
-	#engagements: EngagementCollection
-	#users: UserCollection
-	#notifier: Notifications
-
 	public constructor(
-		localization: Localization,
-		pubsub: PubSub,
-		engagements: EngagementCollection,
-		users: UserCollection,
-		notifier: Notifications
-	) {
-		this.#localization = localization
-		this.#pubsub = pubsub
-		this.#engagements = engagements
-		this.#users = users
-		this.#notifier = notifier
-	}
+		private readonly localization: Localization,
+		private readonly publisher: Publisher,
+		private readonly engagements: EngagementCollection,
+		private readonly users: UserCollection,
+		private readonly notifier: Notifications
+	) {}
 
 	public async execute(
 		body: EngagementInput,
@@ -52,24 +36,22 @@ export class CreateEngagementInteractor implements Interactor<EngagementInput, E
 		const nextEngagement = createDBEngagement({ ...body })
 
 		// Insert engagement into enagements collection
-		await this.#engagements.insertItem(nextEngagement)
+		await this.engagements.insertItem(nextEngagement)
 
 		// User who created the request
 		const user = identity?.id
-		if (!user) throw Error(this.#localization.t('mutation.createEngagement.unauthorized'))
+		if (!user) throw Error(this.localization.t('mutation.createEngagement.unauthorized'))
 
-		await this.#pubsub.publish(`ORG_ENGAGEMENT_UPDATES_${nextEngagement.org_id}`, {
-			action: 'CREATED',
-			message: this.#localization.t('mutation.createEngagement.success'),
-			engagement: createGQLEngagement(nextEngagement),
-			status: StatusType.Success
-		})
+		await this.publisher.publishEngagementCreated(
+			nextEngagement.org_id,
+			createGQLEngagement(nextEngagement)
+		)
 
 		// Create two actions. one for create one for assignment
 		// Engagement create action
 		const actionsToAssign: DbAction[] = [
 			createDBAction({
-				comment: this.#localization.t('mutation.createEngagement.actions.createRequest'),
+				comment: this.localization.t('mutation.createEngagement.actions.createRequest'),
 				orgId: body.orgId,
 				userId: user
 			})
@@ -77,15 +59,15 @@ export class CreateEngagementInteractor implements Interactor<EngagementInput, E
 
 		if (body.userId && user !== body.userId) {
 			// Get user to be assigned
-			const userToAssign = await this.#users.itemById(body.userId)
+			const userToAssign = await this.users.itemById(body.userId)
 			if (!userToAssign.item) {
-				throw Error(this.#localization.t('mutation.createEngagement.unableToAssign'))
+				throw Error(this.localization.t('mutation.createEngagement.unableToAssign'))
 			}
 
 			// User assignment action
 			actionsToAssign.unshift(
 				createDBAction({
-					comment: this.#localization.t('mutation.createEngagement.actions.assignedRequest', {
+					comment: this.localization.t('mutation.createEngagement.actions.assignedRequest', {
 						username: userToAssign.item.user_name
 					}),
 					orgId: body.orgId,
@@ -104,7 +86,7 @@ export class CreateEngagementInteractor implements Interactor<EngagementInput, E
 				)
 
 				try {
-					await this.#users.updateItem(
+					await this.users.updateItem(
 						{ id: userToAssign.item.id },
 						{ $push: { mentions: dbMention } }
 					)
@@ -113,17 +95,12 @@ export class CreateEngagementInteractor implements Interactor<EngagementInput, E
 				}
 
 				// Publish changes to subscribed user
-				await this.#pubsub.publish(`USER_MENTION_UPDATES_${userToAssign.item.id}`, {
-					action: 'CREATED',
-					message: this.#localization.t('mutation.addEngagementAction.success'),
-					mention: createGQLMention(dbMention),
-					status: StatusType.Success
-				})
+				await this.publisher.publishMention(userToAssign.item.id, createGQLMention(dbMention))
 			}
 
 			// Send fcm message if token is present on user
 			if (userToAssign.item.fcm_token) {
-				this.#notifier.assignedRequest(userToAssign.item.fcm_token)
+				this.notifier.assignedRequest(userToAssign.item.fcm_token)
 			}
 		}
 
@@ -131,7 +108,7 @@ export class CreateEngagementInteractor implements Interactor<EngagementInput, E
 			// Create claimed action
 			actionsToAssign.unshift(
 				createDBAction({
-					comment: this.#localization.t('mutation.createEngagement.actions.claimedRequest'),
+					comment: this.localization.t('mutation.createEngagement.actions.claimedRequest'),
 					orgId: body.orgId,
 					userId: user,
 					taggedUserId: user
@@ -141,12 +118,12 @@ export class CreateEngagementInteractor implements Interactor<EngagementInput, E
 			// Set fcm token if present
 			logger('context.auth.identity?.fcm_token', identity?.fcm_token)
 			if (identity?.fcm_token) {
-				this.#notifier.assignedRequest(identity.fcm_token)
+				this.notifier.assignedRequest(identity.fcm_token)
 			}
 		}
 
 		// Assign new action to engagement
-		await this.#engagements.updateItem(
+		await this.engagements.updateItem(
 			{ id: nextEngagement.id },
 			{
 				$push: {
@@ -162,7 +139,7 @@ export class CreateEngagementInteractor implements Interactor<EngagementInput, E
 
 		// Return created engagement
 		return new SuccessEngagementResponse(
-			this.#localization.t('mutation.createEngagement.success'),
+			this.localization.t('mutation.createEngagement.success'),
 			createGQLEngagement(nextEngagement)
 		)
 	}

--- a/packages/api/src/interactors/CreateNewTagInteractor.ts
+++ b/packages/api/src/interactors/CreateNewTagInteractor.ts
@@ -10,41 +10,33 @@ import { Interactor } from '~types'
 import { FailedResponse, SuccessTagResponse } from '~utils/response'
 
 export class CreateNewTagInteractor implements Interactor<OrgTagInput, TagResponse> {
-	#localization: Localization
-	#tags: TagCollection
-	#orgs: OrganizationCollection
-
 	public constructor(
-		localization: Localization,
-		tags: TagCollection,
-		orgs: OrganizationCollection
-	) {
-		this.#localization = localization
-		this.#tags = tags
-		this.#orgs = orgs
-	}
+		private readonly localization: Localization,
+		private readonly tags: TagCollection,
+		private readonly orgs: OrganizationCollection
+	) {}
 
 	public async execute(body: OrgTagInput): Promise<TagResponse> {
 		const { orgId, tag } = body
 		if (!orgId) {
-			return new FailedResponse(this.#localization.t('mutation.createNewTag.orgIdRequired'))
+			return new FailedResponse(this.localization.t('mutation.createNewTag.orgIdRequired'))
 		}
 		const newTag = createDBTag(tag, orgId)
 
 		try {
-			await this.#tags.insertItem(newTag)
+			await this.tags.insertItem(newTag)
 		} catch (err) {
 			throw err
 		}
 
 		try {
-			await this.#orgs.updateItem({ id: orgId }, { $push: { tags: newTag.id } })
+			await this.orgs.updateItem({ id: orgId }, { $push: { tags: newTag.id } })
 		} catch (err) {
 			throw err
 		}
 
 		return new SuccessTagResponse(
-			this.#localization.t('mutation.createNewTag.success'),
+			this.localization.t('mutation.createNewTag.success'),
 			createGQLTag(newTag)
 		)
 	}

--- a/packages/api/src/interactors/CreateNewTagInteractor.ts
+++ b/packages/api/src/interactors/CreateNewTagInteractor.ts
@@ -2,11 +2,12 @@
  * Copyright (c) Microsoft. All rights reserved.
  * Licensed under the MIT license. See LICENSE file in the project.
  */
-import { OrgTagInput, StatusType, TagResponse } from '@cbosuite/schema/dist/provider-types'
+import { OrgTagInput, TagResponse } from '@cbosuite/schema/dist/provider-types'
 import { Localization } from '~components'
 import { OrganizationCollection, TagCollection } from '~db'
 import { createDBTag, createGQLTag } from '~dto'
 import { Interactor } from '~types'
+import { FailedResponse, SuccessTagResponse } from '~utils/response'
 
 export class CreateNewTagInteractor implements Interactor<OrgTagInput, TagResponse> {
 	#localization: Localization
@@ -26,11 +27,7 @@ export class CreateNewTagInteractor implements Interactor<OrgTagInput, TagRespon
 	public async execute(body: OrgTagInput): Promise<TagResponse> {
 		const { orgId, tag } = body
 		if (!orgId) {
-			return {
-				tag: null,
-				message: this.#localization.t('mutation.createNewTag.orgIdRequired'),
-				status: StatusType.Failed
-			}
+			return new FailedResponse(this.#localization.t('mutation.createNewTag.orgIdRequired'))
 		}
 		const newTag = createDBTag(tag, orgId)
 
@@ -46,10 +43,9 @@ export class CreateNewTagInteractor implements Interactor<OrgTagInput, TagRespon
 			throw err
 		}
 
-		return {
-			tag: createGQLTag(newTag),
-			message: this.#localization.t('mutation.createNewTag.success'),
-			status: StatusType.Success
-		}
+		return new SuccessTagResponse(
+			this.#localization.t('mutation.createNewTag.success'),
+			createGQLTag(newTag)
+		)
 	}
 }

--- a/packages/api/src/interactors/CreateNewUserInteractor.ts
+++ b/packages/api/src/interactors/CreateNewUserInteractor.ts
@@ -14,69 +14,56 @@ import { FailedResponse, SuccessUserResponse } from '~utils/response'
 const logger = createLogger('interactors:create-new-user')
 
 export class CreateNewUserInteractor implements Interactor<UserInput, UserResponse> {
-	#localization: Localization
-	#authenticator: Authenticator
-	#mailer: Transporter
-	#users: UserCollection
-	#orgs: OrganizationCollection
-	#config: Configuration
 	public constructor(
-		localization: Localization,
-		authenticator: Authenticator,
-		mailer: Transporter,
-		users: UserCollection,
-		orgs: OrganizationCollection,
-		config: Configuration
-	) {
-		this.#localization = localization
-		this.#authenticator = authenticator
-		this.#mailer = mailer
-		this.#users = users
-		this.#orgs = orgs
-		this.#config = config
-	}
+		private readonly localization: Localization,
+		private readonly authenticator: Authenticator,
+		private readonly mailer: Transporter,
+		private readonly users: UserCollection,
+		private readonly orgs: OrganizationCollection,
+		private readonly config: Configuration
+	) {}
 
 	public async execute(user: UserInput): Promise<UserResponse> {
-		const checkUser = await this.#users.count({
+		const checkUser = await this.users.count({
 			email: user.email
 		})
 
 		if (checkUser !== 0) {
-			return new FailedResponse(this.#localization.t('mutation.createNewUser.emailExist'))
+			return new FailedResponse(this.localization.t('mutation.createNewUser.emailExist'))
 		}
 
 		// If env is production and sendmail is not configured, don't create user.
-		if (!this.#config.isEmailEnabled && this.#config.failOnMailNotEnabled) {
-			return new FailedResponse(this.#localization.t('mutation.createNewUser.emailNotConfigured'))
+		if (!this.config.isEmailEnabled && this.config.failOnMailNotEnabled) {
+			return new FailedResponse(this.localization.t('mutation.createNewUser.emailNotConfigured'))
 		}
 
 		// Generate random password
-		const password = this.#authenticator.generatePassword(16)
+		const password = this.authenticator.generatePassword(16)
 
 		// Create a dbabase object from input values
 		const newUser = createDBUser(user, password)
 
 		await Promise.all([
-			this.#users.insertItem(newUser),
-			this.#orgs.updateItem({ id: newUser.roles[0].org_id }, { $push: { users: newUser.id } })
+			this.users.insertItem(newUser),
+			this.orgs.updateItem({ id: newUser.roles[0].org_id }, { $push: { users: newUser.id } })
 		])
 
-		let successMessage = this.#localization.t('mutation.createNewUser.success')
-		const loginLink = `${this.#config.origin}/login`
-		if (this.#config.isEmailEnabled) {
+		let successMessage = this.localization.t('mutation.createNewUser.success')
+		const loginLink = `${this.config.origin}/login`
+		if (this.config.isEmailEnabled) {
 			try {
-				await this.#mailer.sendMail({
-					from: `${this.#localization.t('mutation.createNewUser.emailHTML.header')} "${
-						this.#config.defaultFromAddress
+				await this.mailer.sendMail({
+					from: `${this.localization.t('mutation.createNewUser.emailHTML.header')} "${
+						this.config.defaultFromAddress
 					}"`,
 					to: user.email,
-					subject: this.#localization.t('mutation.createNewUser.emailSubject'),
-					text: this.#localization.t('mutation.createNewUser.emailBody', { password }),
-					html: getAccountCreatedHTMLTemplate(loginLink, password, this.#localization)
+					subject: this.localization.t('mutation.createNewUser.emailSubject'),
+					text: this.localization.t('mutation.createNewUser.emailBody', { password }),
+					html: getAccountCreatedHTMLTemplate(loginLink, password, this.localization)
 				})
 			} catch (error) {
 				logger('error sending mail', error)
-				return new FailedResponse(this.#localization.t('mutation.createNewUser.emailNotConfigured'))
+				return new FailedResponse(this.localization.t('mutation.createNewUser.emailNotConfigured'))
 			}
 		} else {
 			// return temp password to display in console log.

--- a/packages/api/src/interactors/CreateServiceAnswersInteractor.ts
+++ b/packages/api/src/interactors/CreateServiceAnswersInteractor.ts
@@ -2,17 +2,14 @@
  * Copyright (c) Microsoft. All rights reserved.
  * Licensed under the MIT license. See LICENSE file in the project.
  */
-import {
-	ServiceAnswerInput,
-	ServiceAnswerResponse,
-	StatusType
-} from '@cbosuite/schema/dist/provider-types'
+import { ServiceAnswerInput, ServiceAnswerResponse } from '@cbosuite/schema/dist/provider-types'
 import { Localization } from '~components'
 import { ServiceAnswerCollection, ServiceCollection } from '~db'
 import { createDBServiceAnswer } from '~dto'
 import { createGQLServiceAnswer } from '~dto/createGQLServiceAnswer'
 import { Interactor } from '~types'
 import { validateAnswer } from '~utils/formValidation'
+import { FailedResponse, SuccessServiceAnswerResponse } from '~utils/response'
 
 export class CreateServiceAnswersInteractor
 	implements Interactor<ServiceAnswerInput, ServiceAnswerResponse>
@@ -33,19 +30,15 @@ export class CreateServiceAnswersInteractor
 
 	public async execute(answer: ServiceAnswerInput): Promise<ServiceAnswerResponse> {
 		if (!answer.serviceId) {
-			return {
-				serviceAnswer: null,
-				message: this.#localization.t('mutation.createServiceAnswers.serviceIdRequired'),
-				status: StatusType.Failed
-			}
+			return new FailedResponse(
+				this.#localization.t('mutation.createServiceAnswers.serviceIdRequired')
+			)
 		}
 		const service = await this.#services.itemById(answer.serviceId)
 		if (!service.item) {
-			return {
-				serviceAnswer: null,
-				message: this.#localization.t('mutation.createServiceAnswers.serviceNotFound'),
-				status: StatusType.Failed
-			}
+			return new FailedResponse(
+				this.#localization.t('mutation.createServiceAnswers.serviceNotFound')
+			)
 		}
 
 		validateAnswer(service.item, answer)
@@ -53,10 +46,9 @@ export class CreateServiceAnswersInteractor
 		const dbServiceAnswer = createDBServiceAnswer(answer)
 		this.#serviceAnswers.insertItem(dbServiceAnswer)
 
-		return {
-			serviceAnswer: createGQLServiceAnswer(dbServiceAnswer),
-			message: this.#localization.t('mutation.createServiceAnswers.success'),
-			status: StatusType.Success
-		}
+		return new SuccessServiceAnswerResponse(
+			this.#localization.t('mutation.createServiceAnswers.success'),
+			createGQLServiceAnswer(dbServiceAnswer)
+		)
 	}
 }

--- a/packages/api/src/interactors/CreateServiceAnswersInteractor.ts
+++ b/packages/api/src/interactors/CreateServiceAnswersInteractor.ts
@@ -14,40 +14,32 @@ import { FailedResponse, SuccessServiceAnswerResponse } from '~utils/response'
 export class CreateServiceAnswersInteractor
 	implements Interactor<ServiceAnswerInput, ServiceAnswerResponse>
 {
-	#localization: Localization
-	#services: ServiceCollection
-	#serviceAnswers: ServiceAnswerCollection
-
 	public constructor(
-		localization: Localization,
-		services: ServiceCollection,
-		serviceAnswers: ServiceAnswerCollection
-	) {
-		this.#localization = localization
-		this.#services = services
-		this.#serviceAnswers = serviceAnswers
-	}
+		private readonly localization: Localization,
+		private readonly services: ServiceCollection,
+		private readonly serviceAnswers: ServiceAnswerCollection
+	) {}
 
 	public async execute(answer: ServiceAnswerInput): Promise<ServiceAnswerResponse> {
 		if (!answer.serviceId) {
 			return new FailedResponse(
-				this.#localization.t('mutation.createServiceAnswers.serviceIdRequired')
+				this.localization.t('mutation.createServiceAnswers.serviceIdRequired')
 			)
 		}
-		const service = await this.#services.itemById(answer.serviceId)
+		const service = await this.services.itemById(answer.serviceId)
 		if (!service.item) {
 			return new FailedResponse(
-				this.#localization.t('mutation.createServiceAnswers.serviceNotFound')
+				this.localization.t('mutation.createServiceAnswers.serviceNotFound')
 			)
 		}
 
 		validateAnswer(service.item, answer)
 
 		const dbServiceAnswer = createDBServiceAnswer(answer)
-		this.#serviceAnswers.insertItem(dbServiceAnswer)
+		this.serviceAnswers.insertItem(dbServiceAnswer)
 
 		return new SuccessServiceAnswerResponse(
-			this.#localization.t('mutation.createServiceAnswers.success'),
+			this.localization.t('mutation.createServiceAnswers.success'),
 			createGQLServiceAnswer(dbServiceAnswer)
 		)
 	}

--- a/packages/api/src/interactors/CreateServiceInteractor.ts
+++ b/packages/api/src/interactors/CreateServiceInteractor.ts
@@ -2,11 +2,12 @@
  * Copyright (c) Microsoft. All rights reserved.
  * Licensed under the MIT license. See LICENSE file in the project.
  */
-import { ServiceInput, ServiceResponse, StatusType } from '@cbosuite/schema/dist/provider-types'
+import { ServiceInput, ServiceResponse } from '@cbosuite/schema/dist/provider-types'
 import { Localization } from '~components'
 import { ServiceCollection } from '~db'
 import { createDBService, createGQLService } from '~dto'
 import { Interactor } from '~types'
+import { FailedResponse, SuccessServiceResponse } from '~utils/response'
 
 export class CreateServiceInteractor implements Interactor<ServiceInput, ServiceResponse> {
 	#localization: Localization
@@ -20,19 +21,14 @@ export class CreateServiceInteractor implements Interactor<ServiceInput, Service
 	public async execute(service: ServiceInput): Promise<ServiceResponse> {
 		const newService = createDBService(service)
 		if (!service.orgId) {
-			return {
-				service: null,
-				message: this.#localization.t('mutation.createService.orgIdRequired'),
-				status: StatusType.Failed
-			}
+			return new FailedResponse(this.#localization.t('mutation.createService.orgIdRequired'))
 		}
 
 		await this.#services.insertItem(newService)
 
-		return {
-			service: createGQLService(newService),
-			message: this.#localization.t('mutation.createService.success'),
-			status: StatusType.Success
-		}
+		return new SuccessServiceResponse(
+			this.#localization.t('mutation.createService.success'),
+			createGQLService(newService)
+		)
 	}
 }

--- a/packages/api/src/interactors/CreateServiceInteractor.ts
+++ b/packages/api/src/interactors/CreateServiceInteractor.ts
@@ -10,24 +10,21 @@ import { Interactor } from '~types'
 import { FailedResponse, SuccessServiceResponse } from '~utils/response'
 
 export class CreateServiceInteractor implements Interactor<ServiceInput, ServiceResponse> {
-	#localization: Localization
-	#services: ServiceCollection
-
-	public constructor(localization: Localization, services: ServiceCollection) {
-		this.#localization = localization
-		this.#services = services
-	}
+	public constructor(
+		private readonly localization: Localization,
+		private readonly services: ServiceCollection
+	) {}
 
 	public async execute(service: ServiceInput): Promise<ServiceResponse> {
 		const newService = createDBService(service)
 		if (!service.orgId) {
-			return new FailedResponse(this.#localization.t('mutation.createService.orgIdRequired'))
+			return new FailedResponse(this.localization.t('mutation.createService.orgIdRequired'))
 		}
 
-		await this.#services.insertItem(newService)
+		await this.services.insertItem(newService)
 
 		return new SuccessServiceResponse(
-			this.#localization.t('mutation.createService.success'),
+			this.localization.t('mutation.createService.success'),
 			createGQLService(newService)
 		)
 	}

--- a/packages/api/src/interactors/DeleteServiceAnswerInteractor.ts
+++ b/packages/api/src/interactors/DeleteServiceAnswerInteractor.ts
@@ -2,14 +2,11 @@
  * Copyright (c) Microsoft. All rights reserved.
  * Licensed under the MIT license. See LICENSE file in the project.
  */
-import {
-	ServiceAnswerIdInput,
-	VoidResponse,
-	StatusType
-} from '@cbosuite/schema/dist/provider-types'
+import { ServiceAnswerIdInput, VoidResponse } from '@cbosuite/schema/dist/provider-types'
 import { Localization } from '~components'
 import { ServiceAnswerCollection } from '~db'
 import { Interactor } from '~types'
+import { FailedResponse, SuccessVoidResponse } from '~utils/response'
 
 export class DeleteServiceAnswerInteractor
 	implements Interactor<ServiceAnswerIdInput, VoidResponse>
@@ -24,10 +21,9 @@ export class DeleteServiceAnswerInteractor
 
 	public async execute(serviceAnswer: ServiceAnswerIdInput): Promise<VoidResponse> {
 		if (!serviceAnswer.answerId) {
-			return {
-				message: this.#localization.t('mutation.deleteServiceAnswer.answerIdRequired'),
-				status: StatusType.Failed
-			}
+			return new FailedResponse(
+				this.#localization.t('mutation.deleteServiceAnswer.answerIdRequired')
+			)
 		}
 
 		try {
@@ -38,9 +34,6 @@ export class DeleteServiceAnswerInteractor
 			throw err
 		}
 
-		return {
-			message: this.#localization.t('mutation.deleteServiceAnswer.success'),
-			status: StatusType.Success
-		}
+		return new SuccessVoidResponse(this.#localization.t('mutation.deleteServiceAnswer.success'))
 	}
 }

--- a/packages/api/src/interactors/DeleteServiceAnswerInteractor.ts
+++ b/packages/api/src/interactors/DeleteServiceAnswerInteractor.ts
@@ -11,29 +11,26 @@ import { FailedResponse, SuccessVoidResponse } from '~utils/response'
 export class DeleteServiceAnswerInteractor
 	implements Interactor<ServiceAnswerIdInput, VoidResponse>
 {
-	#localization: Localization
-	#serviceAnswers: ServiceAnswerCollection
-
-	public constructor(localization: Localization, serviceAnswers: ServiceAnswerCollection) {
-		this.#localization = localization
-		this.#serviceAnswers = serviceAnswers
-	}
+	public constructor(
+		private readonly localization: Localization,
+		private readonly serviceAnswers: ServiceAnswerCollection
+	) {}
 
 	public async execute(serviceAnswer: ServiceAnswerIdInput): Promise<VoidResponse> {
 		if (!serviceAnswer.answerId) {
 			return new FailedResponse(
-				this.#localization.t('mutation.deleteServiceAnswer.answerIdRequired')
+				this.localization.t('mutation.deleteServiceAnswer.answerIdRequired')
 			)
 		}
 
 		try {
-			await this.#serviceAnswers.deleteItem({
+			await this.serviceAnswers.deleteItem({
 				id: serviceAnswer.answerId
 			})
 		} catch (err) {
 			throw err
 		}
 
-		return new SuccessVoidResponse(this.#localization.t('mutation.deleteServiceAnswer.success'))
+		return new SuccessVoidResponse(this.localization.t('mutation.deleteServiceAnswer.success'))
 	}
 }

--- a/packages/api/src/interactors/DeleteUserInteractor.ts
+++ b/packages/api/src/interactors/DeleteUserInteractor.ts
@@ -14,24 +14,13 @@ import { Interactor, RequestContext } from '~types'
 import { FailedResponse, SuccessVoidResponse } from '~utils/response'
 
 export class DeleteUserInteractor implements Interactor<UserIdInput, VoidResponse> {
-	#localization: Localization
-	#users: UserCollection
-	#userTokens: UserTokenCollection
-	#orgs: OrganizationCollection
-	#engagements: EngagementCollection
 	public constructor(
-		localization: Localization,
-		users: UserCollection,
-		userTokens: UserTokenCollection,
-		orgs: OrganizationCollection,
-		engagements: EngagementCollection
-	) {
-		this.#localization = localization
-		this.#users = users
-		this.#userTokens = userTokens
-		this.#orgs = orgs
-		this.#engagements = engagements
-	}
+		private readonly localization: Localization,
+		private readonly users: UserCollection,
+		private readonly userTokens: UserTokenCollection,
+		private readonly orgs: OrganizationCollection,
+		private readonly engagements: EngagementCollection
+	) {}
 
 	public async execute(
 		{ userId }: UserIdInput,
@@ -39,21 +28,21 @@ export class DeleteUserInteractor implements Interactor<UserIdInput, VoidRespons
 	): Promise<VoidResponse> {
 		// Delete user
 		try {
-			await this.#users.deleteItem({ id: userId })
+			await this.users.deleteItem({ id: userId })
 		} catch (error) {
-			return new FailedResponse(this.#localization.t('mutation.deleteUser.fail'))
+			return new FailedResponse(this.localization.t('mutation.deleteUser.fail'))
 		}
 
 		// Remove all engagements with user
 		try {
-			await this.#engagements.deleteItems({ user_id: userId })
+			await this.engagements.deleteItems({ user_id: userId })
 		} catch (error) {
-			return new FailedResponse(this.#localization.t('mutation.deleteUser.fail'))
+			return new FailedResponse(this.localization.t('mutation.deleteUser.fail'))
 		}
 
 		// Remove all remaining engagement actions with user
 		try {
-			const remainingEngagementsOnOrg = await this.#engagements.items(
+			const remainingEngagementsOnOrg = await this.engagements.items(
 				{},
 				{ org_id: identity?.roles[0]?.org_id }
 			)
@@ -81,7 +70,7 @@ export class DeleteUserInteractor implements Interactor<UserIdInput, VoidRespons
 
 					// Only update the engagement actions if a user was removed
 					if (removedUser) {
-						await this.#engagements.updateItem(
+						await this.engagements.updateItem(
 							{ id: engagement.id },
 							{
 								$set: {
@@ -93,31 +82,31 @@ export class DeleteUserInteractor implements Interactor<UserIdInput, VoidRespons
 				}
 			}
 		} catch (error) {
-			return new FailedResponse(this.#localization.t('mutation.deleteUser.fail'))
+			return new FailedResponse(this.localization.t('mutation.deleteUser.fail'))
 		}
 
 		// Remove user from organization
 		try {
-			const orgWithUser = await this.#orgs.item({ id: identity?.roles[0].org_id })
+			const orgWithUser = await this.orgs.item({ id: identity?.roles[0].org_id })
 			if (orgWithUser.item) {
 				const nextUsers = orgWithUser.item.users.filter((orgUserId) => orgUserId !== userId)
-				await this.#orgs.updateItem(
+				await this.orgs.updateItem(
 					{ id: identity?.roles[0].org_id },
 					{ $set: { users: nextUsers } }
 				)
 			}
 		} catch (error) {
-			return new FailedResponse(this.#localization.t('mutation.deleteUser.fail'))
+			return new FailedResponse(this.localization.t('mutation.deleteUser.fail'))
 		}
 
 		// Remove user tokens
 		try {
-			await this.#userTokens.deleteItems({ user: userId })
+			await this.userTokens.deleteItems({ user: userId })
 		} catch (error) {
-			return new FailedResponse(this.#localization.t('mutation.deleteUser.fail'))
+			return new FailedResponse(this.localization.t('mutation.deleteUser.fail'))
 		}
 
 		// Return success
-		return new SuccessVoidResponse(this.#localization.t('mutation.deleteUser.success'))
+		return new SuccessVoidResponse(this.localization.t('mutation.deleteUser.success'))
 	}
 }

--- a/packages/api/src/interactors/DeleteUserInteractor.ts
+++ b/packages/api/src/interactors/DeleteUserInteractor.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft. All rights reserved.
  * Licensed under the MIT license. See LICENSE file in the project.
  */
-import { StatusType, UserIdInput, VoidResponse } from '@cbosuite/schema/dist/provider-types'
+import { UserIdInput, VoidResponse } from '@cbosuite/schema/dist/provider-types'
 import { Localization } from '~components'
 import {
 	EngagementCollection,
@@ -11,6 +11,7 @@ import {
 	UserTokenCollection
 } from '~db'
 import { Interactor, RequestContext } from '~types'
+import { FailedResponse, SuccessVoidResponse } from '~utils/response'
 
 export class DeleteUserInteractor implements Interactor<UserIdInput, VoidResponse> {
 	#localization: Localization
@@ -40,20 +41,14 @@ export class DeleteUserInteractor implements Interactor<UserIdInput, VoidRespons
 		try {
 			await this.#users.deleteItem({ id: userId })
 		} catch (error) {
-			return {
-				message: this.#localization.t('mutation.deleteUser.fail'),
-				status: StatusType.Failed
-			}
+			return new FailedResponse(this.#localization.t('mutation.deleteUser.fail'))
 		}
 
 		// Remove all engagements with user
 		try {
 			await this.#engagements.deleteItems({ user_id: userId })
 		} catch (error) {
-			return {
-				message: this.#localization.t('mutation.deleteUser.fail'),
-				status: StatusType.Failed
-			}
+			return new FailedResponse(this.#localization.t('mutation.deleteUser.fail'))
 		}
 
 		// Remove all remaining engagement actions with user
@@ -98,10 +93,7 @@ export class DeleteUserInteractor implements Interactor<UserIdInput, VoidRespons
 				}
 			}
 		} catch (error) {
-			return {
-				message: this.#localization.t('mutation.deleteUser.fail'),
-				status: StatusType.Failed
-			}
+			return new FailedResponse(this.#localization.t('mutation.deleteUser.fail'))
 		}
 
 		// Remove user from organization
@@ -115,26 +107,17 @@ export class DeleteUserInteractor implements Interactor<UserIdInput, VoidRespons
 				)
 			}
 		} catch (error) {
-			return {
-				message: this.#localization.t('mutation.deleteUser.fail'),
-				status: StatusType.Failed
-			}
+			return new FailedResponse(this.#localization.t('mutation.deleteUser.fail'))
 		}
 
 		// Remove user tokens
 		try {
 			await this.#userTokens.deleteItems({ user: userId })
 		} catch (error) {
-			return {
-				message: this.#localization.t('mutation.deleteUser.fail'),
-				status: StatusType.Failed
-			}
+			return new FailedResponse(this.#localization.t('mutation.deleteUser.fail'))
 		}
 
 		// Return success
-		return {
-			message: this.#localization.t('mutation.deleteUser.success'),
-			status: StatusType.Success
-		}
+		return new SuccessVoidResponse(this.#localization.t('mutation.deleteUser.success'))
 	}
 }

--- a/packages/api/src/interactors/ForgotUserPasswordInteractor.ts
+++ b/packages/api/src/interactors/ForgotUserPasswordInteractor.ts
@@ -4,8 +4,7 @@
  */
 import {
 	ForgotUserPasswordInput,
-	ForgotUserPasswordResponse,
-	StatusType
+	ForgotUserPasswordResponse
 } from '@cbosuite/schema/dist/provider-types'
 import { Transporter } from 'nodemailer'
 import { Authenticator, Configuration, Localization } from '~components'

--- a/packages/api/src/interactors/ForgotUserPasswordInteractor.ts
+++ b/packages/api/src/interactors/ForgotUserPasswordInteractor.ts
@@ -2,59 +2,44 @@
  * Copyright (c) Microsoft. All rights reserved.
  * Licensed under the MIT license. See LICENSE file in the project.
  */
-import {
-	ForgotUserPasswordInput,
-	ForgotUserPasswordResponse
-} from '@cbosuite/schema/dist/provider-types'
+import { ForgotUserPasswordInput, VoidResponse } from '@cbosuite/schema/dist/provider-types'
 import { Transporter } from 'nodemailer'
 import { Authenticator, Configuration, Localization } from '~components'
 import { UserCollection } from '~db'
 import { Interactor } from '~types'
 import { getForgotPasswordHTMLTemplate, createLogger } from '~utils'
-import { FailedResponse, SuccessForgotUserPasswordResponse } from '~utils/response'
+import { FailedResponse, SuccessVoidResponse } from '~utils/response'
 
 const logger = createLogger('interactors:forgot-user-password')
 
 export class ForgotUserPasswordInteractor
-	implements Interactor<ForgotUserPasswordInput, ForgotUserPasswordResponse>
+	implements Interactor<ForgotUserPasswordInput, VoidResponse>
 {
-	#config: Configuration
-	#localization: Localization
-	#users: UserCollection
-	#authenticator: Authenticator
-	#mailer: Transporter
-
 	public constructor(
-		config: Configuration,
-		localization: Localization,
-		authenticator: Authenticator,
-		users: UserCollection,
-		mailer: Transporter
-	) {
-		this.#config = config
-		this.#localization = localization
-		this.#users = users
-		this.#authenticator = authenticator
-		this.#mailer = mailer
-	}
+		private readonly config: Configuration,
+		private readonly localization: Localization,
+		private readonly authenticator: Authenticator,
+		private readonly users: UserCollection,
+		private readonly mailer: Transporter
+	) {}
 
-	public async execute(body: ForgotUserPasswordInput): Promise<ForgotUserPasswordResponse> {
+	public async execute(body: ForgotUserPasswordInput): Promise<VoidResponse> {
 		const { email } = body
-		const user = await this.#users.item({ email })
+		const user = await this.users.item({ email })
 
 		if (!user.item) {
-			return new FailedResponse(this.#localization.t('mutation.forgotUserPassword.userNotFound'))
+			return new FailedResponse(this.localization.t('mutation.forgotUserPassword.userNotFound'))
 		}
 
-		if (!this.#config.isEmailEnabled && this.#config.failOnMailNotEnabled) {
+		if (!this.config.isEmailEnabled && this.config.failOnMailNotEnabled) {
 			return new FailedResponse(
-				this.#localization.t('mutation.forgotUserPassword.emailNotConfigured')
+				this.localization.t('mutation.forgotUserPassword.emailNotConfigured')
 			)
 		}
-		//const forgotPasswordToken = this.#authenticator.generatePassword(25, true)
-		const forgotPasswordToken = this.#authenticator.generatePasswordResetToken()
+		//const forgotPasswordToken = this.authenticator.generatePassword(25, true)
+		const forgotPasswordToken = this.authenticator.generatePasswordResetToken()
 
-		await this.#users.updateItem(
+		await this.users.updateItem(
 			{ email: email },
 			{
 				$set: {
@@ -63,27 +48,25 @@ export class ForgotUserPasswordInteractor
 			}
 		)
 
-		let successMessage = this.#localization.t('mutation.forgotUserPassword.success')
-		const resetLink = `${
-			this.#config.origin
-		}/passwordReset?email=${email}&resetToken=${forgotPasswordToken}`
-		if (this.#config.isEmailEnabled) {
+		let successMessage = this.localization.t('mutation.forgotUserPassword.success')
+		const resetLink = `${this.config.origin}/passwordReset?email=${email}&resetToken=${forgotPasswordToken}`
+		if (this.config.isEmailEnabled) {
 			try {
-				await this.#mailer.sendMail({
-					from: `${this.#localization.t('mutation.forgotUserPassword.emailHTML.header')} "${
-						this.#config.defaultFromAddress
+				await this.mailer.sendMail({
+					from: `${this.localization.t('mutation.forgotUserPassword.emailHTML.header')} "${
+						this.config.defaultFromAddress
 					}"`,
 					to: user.item.email,
-					subject: this.#localization.t('mutation.forgotUserPassword.emailSubject'),
-					text: this.#localization.t('mutation.forgotUserPassword.emailBody', {
+					subject: this.localization.t('mutation.forgotUserPassword.emailSubject'),
+					text: this.localization.t('mutation.forgotUserPassword.emailBody', {
 						forgotPasswordToken
 					}),
-					html: getForgotPasswordHTMLTemplate(resetLink, this.#localization)
+					html: getForgotPasswordHTMLTemplate(resetLink, this.localization)
 				})
 			} catch (error) {
 				logger('error sending mail', error)
 				return new FailedResponse(
-					this.#localization.t('mutation.forgotUserPassword.emailNotConfigured')
+					this.localization.t('mutation.forgotUserPassword.emailNotConfigured')
 				)
 			}
 		} else {
@@ -91,6 +74,6 @@ export class ForgotUserPasswordInteractor
 			successMessage = `SUCCESS_NO_MAIL: password reset link: ${resetLink}`
 		}
 
-		return new SuccessForgotUserPasswordResponse(successMessage)
+		return new SuccessVoidResponse(successMessage)
 	}
 }

--- a/packages/api/src/interactors/MarkMentionDismissedInteractor.ts
+++ b/packages/api/src/interactors/MarkMentionDismissedInteractor.ts
@@ -2,11 +2,12 @@
  * Copyright (c) Microsoft. All rights reserved.
  * Licensed under the MIT license. See LICENSE file in the project.
  */
-import { MentionUserInput, StatusType, UserResponse } from '@cbosuite/schema/dist/provider-types'
+import { MentionUserInput, UserResponse } from '@cbosuite/schema/dist/provider-types'
 import { Localization } from '~components'
 import { DbMention, UserCollection } from '~db'
 import { createGQLUser } from '~dto'
 import { Interactor } from '~types'
+import { FailedResponse, SuccessUserResponse } from '~utils/response'
 
 export class MarkMentionDismissedInteractor implements Interactor<MentionUserInput, UserResponse> {
 	#localization: Localization
@@ -22,11 +23,7 @@ export class MarkMentionDismissedInteractor implements Interactor<MentionUserInp
 		const result = await this.#users.itemById(userId)
 
 		if (!result.item) {
-			return {
-				user: null,
-				message: this.#localization.t('mutation.markMentionDismissed.userNotFound'),
-				status: StatusType.Failed
-			}
+			return new FailedResponse(this.#localization.t('mutation.markMentionDismissed.userNotFound'))
 		}
 
 		const dbUser = result.item
@@ -41,10 +38,9 @@ export class MarkMentionDismissedInteractor implements Interactor<MentionUserInp
 
 		await this.#users.saveItem(dbUser)
 
-		return {
-			user: createGQLUser(dbUser),
-			message: this.#localization.t('mutation.markMentionDismissed.success'),
-			status: StatusType.Success
-		}
+		return new SuccessUserResponse(
+			this.#localization.t('mutation.markMentionDismissed.success'),
+			createGQLUser(dbUser)
+		)
 	}
 }

--- a/packages/api/src/interactors/MarkMentionDismissedInteractor.ts
+++ b/packages/api/src/interactors/MarkMentionDismissedInteractor.ts
@@ -10,20 +10,17 @@ import { Interactor } from '~types'
 import { FailedResponse, SuccessUserResponse } from '~utils/response'
 
 export class MarkMentionDismissedInteractor implements Interactor<MentionUserInput, UserResponse> {
-	#localization: Localization
-	#users: UserCollection
-
-	public constructor(localization: Localization, users: UserCollection) {
-		this.#localization = localization
-		this.#users = users
-	}
+	public constructor(
+		private readonly localization: Localization,
+		private readonly users: UserCollection
+	) {}
 
 	public async execute(body: MentionUserInput): Promise<UserResponse> {
 		const { userId, engId: engagementId, dismissAll, createdAt } = body
-		const result = await this.#users.itemById(userId)
+		const result = await this.users.itemById(userId)
 
 		if (!result.item) {
-			return new FailedResponse(this.#localization.t('mutation.markMentionDismissed.userNotFound'))
+			return new FailedResponse(this.localization.t('mutation.markMentionDismissed.userNotFound'))
 		}
 
 		const dbUser = result.item
@@ -36,10 +33,10 @@ export class MarkMentionDismissedInteractor implements Interactor<MentionUserInp
 			}
 		})
 
-		await this.#users.saveItem(dbUser)
+		await this.users.saveItem(dbUser)
 
 		return new SuccessUserResponse(
-			this.#localization.t('mutation.markMentionDismissed.success'),
+			this.localization.t('mutation.markMentionDismissed.success'),
 			createGQLUser(dbUser)
 		)
 	}

--- a/packages/api/src/interactors/MarkMentionSeenInteractor.ts
+++ b/packages/api/src/interactors/MarkMentionSeenInteractor.ts
@@ -2,11 +2,12 @@
  * Copyright (c) Microsoft. All rights reserved.
  * Licensed under the MIT license. See LICENSE file in the project.
  */
-import { MentionUserInput, StatusType, UserResponse } from '@cbosuite/schema/dist/provider-types'
+import { MentionUserInput, UserResponse } from '@cbosuite/schema/dist/provider-types'
 import { Localization } from '~components'
 import { DbMention, UserCollection } from '~db'
 import { createGQLUser } from '~dto'
 import { Interactor } from '~types'
+import { FailedResponse, SuccessUserResponse } from '~utils/response'
 
 export class MarkMentionSeenInteractor implements Interactor<MentionUserInput, UserResponse> {
 	#localization: Localization
@@ -22,11 +23,7 @@ export class MarkMentionSeenInteractor implements Interactor<MentionUserInput, U
 		const result = await this.#users.itemById(userId)
 
 		if (!result.item) {
-			return {
-				user: null,
-				message: this.#localization.t('mutation.markMentionSeen.userNotFound'),
-				status: StatusType.Failed
-			}
+			return new FailedResponse(this.#localization.t('mutation.markMentionSeen.userNotFound'))
 		}
 
 		const dbUser = result.item
@@ -41,10 +38,9 @@ export class MarkMentionSeenInteractor implements Interactor<MentionUserInput, U
 
 		await this.#users.saveItem(dbUser)
 
-		return {
-			user: createGQLUser(dbUser),
-			message: this.#localization.t('mutation.markMentionSeen.success'),
-			status: StatusType.Success
-		}
+		return new SuccessUserResponse(
+			this.#localization.t('mutation.markMentionSeen.success'),
+			createGQLUser(dbUser)
+		)
 	}
 }

--- a/packages/api/src/interactors/MarkMentionSeenInteractor.ts
+++ b/packages/api/src/interactors/MarkMentionSeenInteractor.ts
@@ -10,20 +10,17 @@ import { Interactor } from '~types'
 import { FailedResponse, SuccessUserResponse } from '~utils/response'
 
 export class MarkMentionSeenInteractor implements Interactor<MentionUserInput, UserResponse> {
-	#localization: Localization
-	#users: UserCollection
-
-	public constructor(localization: Localization, users: UserCollection) {
-		this.#localization = localization
-		this.#users = users
-	}
+	public constructor(
+		private readonly localization: Localization,
+		private readonly users: UserCollection
+	) {}
 
 	public async execute(body: MentionUserInput): Promise<UserResponse> {
 		const { userId, engId: engagementId, markAll, createdAt } = body
-		const result = await this.#users.itemById(userId)
+		const result = await this.users.itemById(userId)
 
 		if (!result.item) {
-			return new FailedResponse(this.#localization.t('mutation.markMentionSeen.userNotFound'))
+			return new FailedResponse(this.localization.t('mutation.markMentionSeen.userNotFound'))
 		}
 
 		const dbUser = result.item
@@ -36,10 +33,10 @@ export class MarkMentionSeenInteractor implements Interactor<MentionUserInput, U
 			}
 		})
 
-		await this.#users.saveItem(dbUser)
+		await this.users.saveItem(dbUser)
 
 		return new SuccessUserResponse(
-			this.#localization.t('mutation.markMentionSeen.success'),
+			this.localization.t('mutation.markMentionSeen.success'),
 			createGQLUser(dbUser)
 		)
 	}

--- a/packages/api/src/interactors/SetEngagementStatusInteractor.ts
+++ b/packages/api/src/interactors/SetEngagementStatusInteractor.ts
@@ -15,6 +15,7 @@ import { EngagementCollection } from '~db'
 import { createDBAction, createGQLEngagement } from '~dto'
 import { Interactor, RequestContext } from '~types'
 import { sortByDate } from '~utils'
+import { FailedResponse, SuccessEngagementResponse } from '~utils/response'
 
 export class SetEngagementStatusInteractor
 	implements Interactor<EngagementStatusInput, EngagementResponse>
@@ -37,11 +38,9 @@ export class SetEngagementStatusInteractor
 		const { engId: id, status } = body
 		const engagement = await this.#engagements.itemById(id)
 		if (!engagement.item) {
-			return {
-				engagement: null,
-				message: this.#localization.t('mutation.setEngagementStatus.requestNotFound'),
-				status: StatusType.Failed
-			}
+			return new FailedResponse(
+				this.#localization.t('mutation.setEngagementStatus.requestNotFound')
+			)
 		}
 
 		// Set status
@@ -72,10 +71,9 @@ export class SetEngagementStatusInteractor
 			})
 		}
 
-		return {
-			engagement: createGQLEngagement(engagement.item),
-			message: this.#localization.t('mutation.setEngagementStatus.success'),
-			status: StatusType.Success
-		}
+		return new SuccessEngagementResponse(
+			this.#localization.t('mutation.setEngagementStatus.success'),
+			createGQLEngagement(engagement.item)
+		)
 	}
 }

--- a/packages/api/src/interactors/SetEngagementStatusInteractor.ts
+++ b/packages/api/src/interactors/SetEngagementStatusInteractor.ts
@@ -6,11 +6,10 @@
 import {
 	EngagementResponse,
 	EngagementStatus,
-	EngagementStatusInput,
-	StatusType
+	EngagementStatusInput
 } from '@cbosuite/schema/dist/provider-types'
-import { PubSub } from 'graphql-subscriptions'
 import { Localization } from '~components'
+import { Publisher } from '~components/Publisher'
 import { EngagementCollection } from '~db'
 import { createDBAction, createGQLEngagement } from '~dto'
 import { Interactor, RequestContext } from '~types'
@@ -20,31 +19,21 @@ import { FailedResponse, SuccessEngagementResponse } from '~utils/response'
 export class SetEngagementStatusInteractor
 	implements Interactor<EngagementStatusInput, EngagementResponse>
 {
-	#localization: Localization
-	#engagements: EngagementCollection
-	#pubsub: PubSub
-
 	public constructor(
-		localization: Localization,
-		engagements: EngagementCollection,
-		pubsub: PubSub
-	) {
-		this.#localization = localization
-		this.#engagements = engagements
-		this.#pubsub = pubsub
-	}
+		private readonly localization: Localization,
+		private readonly engagements: EngagementCollection,
+		private readonly publisher: Publisher
+	) {}
 
 	public async execute(body: EngagementStatusInput, { identity }: RequestContext) {
 		const { engId: id, status } = body
-		const engagement = await this.#engagements.itemById(id)
+		const engagement = await this.engagements.itemById(id)
 		if (!engagement.item) {
-			return new FailedResponse(
-				this.#localization.t('mutation.setEngagementStatus.requestNotFound')
-			)
+			return new FailedResponse(this.localization.t('mutation.setEngagementStatus.requestNotFound'))
 		}
 
 		// Set status
-		await this.#engagements.updateItem({ id }, { $set: { status } })
+		await this.engagements.updateItem({ id }, { $set: { status } })
 		engagement.item.status = status
 
 		if (status === EngagementStatus.Closed) {
@@ -52,27 +41,25 @@ export class SetEngagementStatusInteractor
 			const currentUserId = identity?.id
 			if (currentUserId) {
 				const nextAction = createDBAction({
-					comment: this.#localization.t('mutation.setEngagementStatus.actions.markComplete'),
+					comment: this.localization.t('mutation.setEngagementStatus.actions.markComplete'),
 					orgId: engagement.item.org_id,
 					userId: currentUserId,
 					taggedUserId: currentUserId
 				})
 
-				await this.#engagements.updateItem({ id }, { $push: { actions: nextAction } })
+				await this.engagements.updateItem({ id }, { $push: { actions: nextAction } })
 				engagement.item.actions = [...engagement.item.actions, nextAction].sort(sortByDate)
 			}
 
 			// Publish changes to websocketk connection
-			await this.#pubsub.publish(`ORG_ENGAGEMENT_UPDATES_${engagement.item.org_id}`, {
-				action: EngagementStatus.Closed,
-				message: this.#localization.t('mutation.setEngagementStatus.success'),
-				engagement: createGQLEngagement(engagement.item),
-				status: StatusType.Success
-			})
+			await this.publisher.publishEngagementClosed(
+				engagement.item.org_id,
+				createGQLEngagement(engagement.item)
+			)
 		}
 
 		return new SuccessEngagementResponse(
-			this.#localization.t('mutation.setEngagementStatus.success'),
+			this.localization.t('mutation.setEngagementStatus.success'),
 			createGQLEngagement(engagement.item)
 		)
 	}

--- a/packages/api/src/interactors/SetUserPasswordInteractor.ts
+++ b/packages/api/src/interactors/SetUserPasswordInteractor.ts
@@ -10,13 +10,10 @@ import { validatePassword } from '~utils'
 import { FailedResponse, SuccessUserResponse } from '~utils/response'
 
 export class SetUserPasswordInteractor implements Interactor<PasswordChangeInput, UserResponse> {
-	#localization: Localization
-	#authenticator: Authenticator
-
-	public constructor(localization: Localization, authenticator: Authenticator) {
-		this.#localization = localization
-		this.#authenticator = authenticator
-	}
+	public constructor(
+		private readonly localization: Localization,
+		private readonly authenticator: Authenticator
+	) {}
 
 	public async execute(
 		body: PasswordChangeInput,
@@ -24,21 +21,21 @@ export class SetUserPasswordInteractor implements Interactor<PasswordChangeInput
 	): Promise<UserResponse> {
 		const { oldPassword, newPassword } = body
 		if (!user) {
-			return new FailedResponse(this.#localization.t('mutation.setUserPassword.notLoggedIn'))
+			return new FailedResponse(this.localization.t('mutation.setUserPassword.notLoggedIn'))
 		}
 
 		if (!validatePassword(oldPassword, user.password)) {
-			return new FailedResponse(this.#localization.t('mutation.setUserPassword.invalidPassword'))
+			return new FailedResponse(this.localization.t('mutation.setUserPassword.invalidPassword'))
 		}
 
-		const response = await this.#authenticator.setPassword(user, newPassword)
+		const response = await this.authenticator.setPassword(user, newPassword)
 
 		if (!response) {
-			return new FailedResponse(this.#localization.t('mutation.setUserPassword.resetError'))
+			return new FailedResponse(this.localization.t('mutation.setUserPassword.resetError'))
 		}
 
 		return new SuccessUserResponse(
-			this.#localization.t('mutation.setUserPassword.success'),
+			this.localization.t('mutation.setUserPassword.success'),
 			createGQLUser(user)
 		)
 	}

--- a/packages/api/src/interactors/SetUserPasswordInteractor.ts
+++ b/packages/api/src/interactors/SetUserPasswordInteractor.ts
@@ -2,19 +2,14 @@
  * Copyright (c) Microsoft. All rights reserved.
  * Licensed under the MIT license. See LICENSE file in the project.
  */
-import {
-	PasswordChangeInput,
-	StatusType,
-	UserActionResponse
-} from '@cbosuite/schema/dist/provider-types'
+import { PasswordChangeInput, UserResponse } from '@cbosuite/schema/dist/provider-types'
 import { Authenticator, Localization } from '~components'
 import { createGQLUser } from '~dto'
 import { Interactor, RequestContext } from '~types'
 import { validatePassword } from '~utils'
+import { FailedResponse, SuccessUserResponse } from '~utils/response'
 
-export class SetUserPasswordInteractor
-	implements Interactor<PasswordChangeInput, UserActionResponse>
-{
+export class SetUserPasswordInteractor implements Interactor<PasswordChangeInput, UserResponse> {
 	#localization: Localization
 	#authenticator: Authenticator
 
@@ -26,38 +21,25 @@ export class SetUserPasswordInteractor
 	public async execute(
 		body: PasswordChangeInput,
 		{ identity: user }: RequestContext
-	): Promise<UserActionResponse> {
+	): Promise<UserResponse> {
 		const { oldPassword, newPassword } = body
 		if (!user) {
-			return {
-				user: null,
-				message: this.#localization.t('mutation.setUserPassword.notLoggedIn'),
-				status: StatusType.Failed
-			}
+			return new FailedResponse(this.#localization.t('mutation.setUserPassword.notLoggedIn'))
 		}
 
 		if (!validatePassword(oldPassword, user.password)) {
-			return {
-				user: null,
-				message: this.#localization.t('mutation.setUserPassword.invalidPassword'),
-				status: StatusType.Failed
-			}
+			return new FailedResponse(this.#localization.t('mutation.setUserPassword.invalidPassword'))
 		}
 
 		const response = await this.#authenticator.setPassword(user, newPassword)
 
 		if (!response) {
-			return {
-				user: null,
-				message: this.#localization.t('mutation.setUserPassword.resetError'),
-				status: StatusType.Failed
-			}
+			return new FailedResponse(this.#localization.t('mutation.setUserPassword.resetError'))
 		}
 
-		return {
-			user: createGQLUser(user),
-			message: this.#localization.t('mutation.setUserPassword.success'),
-			status: StatusType.Success
-		}
+		return new SuccessUserResponse(
+			this.#localization.t('mutation.setUserPassword.success'),
+			createGQLUser(user)
+		)
 	}
 }

--- a/packages/api/src/interactors/UpdateContactInteractor.ts
+++ b/packages/api/src/interactors/UpdateContactInteractor.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft. All rights reserved.
  * Licensed under the MIT license. See LICENSE file in the project.
  */
-import { ContactInput, ContactResponse, StatusType } from '@cbosuite/schema/dist/provider-types'
+import { ContactInput, ContactResponse } from '@cbosuite/schema/dist/provider-types'
 import { Configuration, Localization } from '~components'
 import {
 	ContactCollection,

--- a/packages/api/src/interactors/UpdateContactInteractor.ts
+++ b/packages/api/src/interactors/UpdateContactInteractor.ts
@@ -3,55 +3,30 @@
  * Licensed under the MIT license. See LICENSE file in the project.
  */
 import { ContactInput, ContactResponse } from '@cbosuite/schema/dist/provider-types'
-import { Configuration, Localization } from '~components'
-import {
-	ContactCollection,
-	TagCollection,
-	DbContact,
-	EngagementCollection,
-	OrganizationCollection
-} from '~db'
+import { Localization } from '~components'
+import { ContactCollection, DbContact } from '~db'
 import { createGQLContact } from '~dto'
 import { Interactor } from '~types'
 import { FailedResponse, SuccessContactResponse } from '~utils/response'
 
 export class UpdateContactInteractor implements Interactor<ContactInput, ContactResponse> {
-	#localization: Localization
-	#config: Configuration
-	#contacts: ContactCollection
-	#tags: TagCollection
-	#engagements: EngagementCollection
-	#orgs: OrganizationCollection
-
 	public constructor(
-		localization: Localization,
-		config: Configuration,
-		contacts: ContactCollection,
-		tags: TagCollection,
-		engagements: EngagementCollection,
-		orgs: OrganizationCollection
-	) {
-		this.#localization = localization
-		this.#config = config
-		this.#contacts = contacts
-		this.#contacts = contacts
-		this.#engagements = engagements
-		this.#orgs = orgs
-		this.#tags = tags
-	}
+		private readonly localization: Localization,
+		private readonly contacts: ContactCollection
+	) {}
 
 	public async execute(contact: ContactInput): Promise<ContactResponse> {
 		if (!contact.id) {
-			return new FailedResponse(this.#localization.t('mutation.updateContact.contactIdRequired'))
+			return new FailedResponse(this.localization.t('mutation.updateContact.contactIdRequired'))
 		}
 
 		if (!contact.orgId) {
-			return new FailedResponse(this.#localization.t('mutation.updateContact.orgIdRequired'))
+			return new FailedResponse(this.localization.t('mutation.updateContact.orgIdRequired'))
 		}
 
-		const result = await this.#contacts.itemById(contact.id)
+		const result = await this.contacts.itemById(contact.id)
 		if (!result.item) {
-			return new FailedResponse(this.#localization.t('mutation.updateContact.userNotFound'))
+			return new FailedResponse(this.localization.t('mutation.updateContact.userNotFound'))
 		}
 		const dbContact = result.item
 
@@ -88,7 +63,7 @@ export class UpdateContactInteractor implements Interactor<ContactInput, Contact
 			tags: contact?.tags || undefined
 		}
 
-		await this.#contacts.updateItem(
+		await this.contacts.updateItem(
 			{ id: dbContact.id },
 			{
 				$set: changedData
@@ -96,7 +71,7 @@ export class UpdateContactInteractor implements Interactor<ContactInput, Contact
 		)
 
 		return new SuccessContactResponse(
-			this.#localization.t('mutation.updateContact.success'),
+			this.localization.t('mutation.updateContact.success'),
 			createGQLContact(changedData)
 		)
 	}

--- a/packages/api/src/interactors/UpdateContactInteractor.ts
+++ b/packages/api/src/interactors/UpdateContactInteractor.ts
@@ -13,6 +13,7 @@ import {
 } from '~db'
 import { createGQLContact } from '~dto'
 import { Interactor } from '~types'
+import { FailedResponse, SuccessContactResponse } from '~utils/response'
 
 export class UpdateContactInteractor implements Interactor<ContactInput, ContactResponse> {
 	#localization: Localization
@@ -41,28 +42,16 @@ export class UpdateContactInteractor implements Interactor<ContactInput, Contact
 
 	public async execute(contact: ContactInput): Promise<ContactResponse> {
 		if (!contact.id) {
-			return {
-				contact: null,
-				message: this.#localization.t('mutation.updateContact.contactIdRequired'),
-				status: StatusType.Failed
-			}
+			return new FailedResponse(this.#localization.t('mutation.updateContact.contactIdRequired'))
 		}
 
 		if (!contact.orgId) {
-			return {
-				contact: null,
-				message: this.#localization.t('mutation.updateContact.orgIdRequired'),
-				status: StatusType.Failed
-			}
+			return new FailedResponse(this.#localization.t('mutation.updateContact.orgIdRequired'))
 		}
 
 		const result = await this.#contacts.itemById(contact.id)
 		if (!result.item) {
-			return {
-				contact: null,
-				message: this.#localization.t('mutation.updateContact.userNotFound'),
-				status: StatusType.Failed
-			}
+			return new FailedResponse(this.#localization.t('mutation.updateContact.userNotFound'))
 		}
 		const dbContact = result.item
 
@@ -106,10 +95,9 @@ export class UpdateContactInteractor implements Interactor<ContactInput, Contact
 			}
 		)
 
-		return {
-			contact: createGQLContact(changedData),
-			message: this.#localization.t('mutation.updateContact.success'),
-			status: StatusType.Success
-		}
+		return new SuccessContactResponse(
+			this.#localization.t('mutation.updateContact.success'),
+			createGQLContact(changedData)
+		)
 	}
 }

--- a/packages/api/src/interactors/UpdateEngagementInteractor.ts
+++ b/packages/api/src/interactors/UpdateEngagementInteractor.ts
@@ -2,13 +2,9 @@
  * Copyright (c) Microsoft. All rights reserved.
  * Licensed under the MIT license. See LICENSE file in the project.
  */
-import {
-	EngagementInput,
-	EngagementResponse,
-	StatusType
-} from '@cbosuite/schema/dist/provider-types'
-import { PubSub } from 'graphql-subscriptions'
+import { EngagementInput, EngagementResponse } from '@cbosuite/schema/dist/provider-types'
 import { Localization } from '~components'
+import { Publisher } from '~components/Publisher'
 import { DbAction, DbEngagement, EngagementCollection, UserCollection } from '~db'
 import { createDBAction, createGQLEngagement } from '~dto'
 import { Interactor, RequestContext } from '~types'
@@ -16,40 +12,30 @@ import { sortByDate } from '~utils'
 import { FailedResponse, SuccessEngagementResponse } from '~utils/response'
 
 export class UpdateEngagementInteractor implements Interactor<EngagementInput, EngagementResponse> {
-	#localization: Localization
-	#pubsub: PubSub
-	#engagements: EngagementCollection
-	#users: UserCollection
-
 	public constructor(
-		localization: Localization,
-		pubsub: PubSub,
-		engagements: EngagementCollection,
-		users: UserCollection
-	) {
-		this.#localization = localization
-		this.#pubsub = pubsub
-		this.#engagements = engagements
-		this.#users = users
-	}
+		private readonly localization: Localization,
+		private readonly publisher: Publisher,
+		private readonly engagements: EngagementCollection,
+		private readonly users: UserCollection
+	) {}
 
 	public async execute(
 		body: EngagementInput,
 		{ identity }: RequestContext
 	): Promise<EngagementResponse> {
 		if (!body?.engagementId) {
-			return new FailedResponse(this.#localization.t('mutation.updateEngagement.noRequestId'))
+			return new FailedResponse(this.localization.t('mutation.updateEngagement.noRequestId'))
 		}
 
-		const result = await this.#engagements.itemById(body.engagementId)
+		const result = await this.engagements.itemById(body.engagementId)
 		if (!result.item) {
-			return new FailedResponse(this.#localization.t('mutation.updateEngagement.requestNotFound'))
+			return new FailedResponse(this.localization.t('mutation.updateEngagement.requestNotFound'))
 		}
 
 		// User who created the request
 		const user = identity?.id
 		if (!user) {
-			return new FailedResponse(this.#localization.t('mutation.updateEngagement.unauthorized'))
+			return new FailedResponse(this.localization.t('mutation.updateEngagement.unauthorized'))
 		}
 
 		const current = result.item
@@ -64,23 +50,21 @@ export class UpdateEngagementInteractor implements Interactor<EngagementInput, E
 		}
 
 		await Promise.all([
-			this.#engagements.updateItem(
+			this.engagements.updateItem(
 				{ id: current.id },
 				{
 					$set: changedItems
 				}
 			),
-			this.#pubsub.publish(`ORG_ENGAGEMENT_UPDATES_${changedItems.org_id}`, {
-				action: 'UPDATED',
-				message: this.#localization.t('mutation.updateEngagement.success'),
-				engagement: createGQLEngagement(changedItems),
-				status: StatusType.Success
-			})
+			this.publisher.publishEngagementUpdated(
+				changedItems.org_id,
+				createGQLEngagement(changedItems)
+			)
 		])
 
 		const actionsToAssign: DbAction[] = [
 			createDBAction({
-				comment: this.#localization.t('mutation.updateEngagement.actions.updatedRequest'),
+				comment: this.localization.t('mutation.updateEngagement.actions.updatedRequest'),
 				orgId: body.orgId,
 				userId: user
 			})
@@ -88,12 +72,12 @@ export class UpdateEngagementInteractor implements Interactor<EngagementInput, E
 
 		if (body.userId && body.userId !== current.user_id && user !== body.userId) {
 			// Get user to be assigned
-			const userToAssign = await this.#users.itemById(body.userId)
+			const userToAssign = await this.users.itemById(body.userId)
 
 			if (!userToAssign.item) {
 				actionsToAssign.unshift(
 					createDBAction({
-						comment: this.#localization.t('mutation.updateEngagement.actions.unassignRequest'),
+						comment: this.localization.t('mutation.updateEngagement.actions.unassignRequest'),
 						orgId: body.orgId,
 						userId: user,
 						taggedUserId: undefined
@@ -104,7 +88,7 @@ export class UpdateEngagementInteractor implements Interactor<EngagementInput, E
 			// Create reassignment action
 			actionsToAssign.unshift(
 				createDBAction({
-					comment: this.#localization.t('mutation.updateEngagement.actions.reassignRequest', {
+					comment: this.localization.t('mutation.updateEngagement.actions.reassignRequest', {
 						username: userToAssign?.item?.user_name
 					}),
 					orgId: body.orgId,
@@ -115,7 +99,7 @@ export class UpdateEngagementInteractor implements Interactor<EngagementInput, E
 		}
 
 		// Assign new action to engagement
-		await this.#engagements.updateItem(
+		await this.engagements.updateItem(
 			{ id: changedItems.id },
 			{
 				$push: {
@@ -131,7 +115,7 @@ export class UpdateEngagementInteractor implements Interactor<EngagementInput, E
 
 		// Return created engagement
 		return new SuccessEngagementResponse(
-			this.#localization.t('mutation.updateEngagement.success'),
+			this.localization.t('mutation.updateEngagement.success'),
 			createGQLEngagement(changedItems)
 		)
 	}

--- a/packages/api/src/interactors/UpdateServiceAnswerInteractor.ts
+++ b/packages/api/src/interactors/UpdateServiceAnswerInteractor.ts
@@ -2,11 +2,7 @@
  * Copyright (c) Microsoft. All rights reserved.
  * Licensed under the MIT license. See LICENSE file in the project.
  */
-import {
-	ServiceAnswerInput,
-	ServiceAnswerResponse,
-	StatusType
-} from '@cbosuite/schema/dist/provider-types'
+import { ServiceAnswerInput, ServiceAnswerResponse } from '@cbosuite/schema/dist/provider-types'
 import { Localization } from '~components'
 import { ServiceCollection } from '~db'
 import { ServiceAnswerCollection } from '~db/ServiceAnswerCollection'
@@ -15,6 +11,7 @@ import { createGQLServiceAnswer } from '~dto/createGQLServiceAnswer'
 import { Interactor } from '~types'
 import { validateAnswer } from '~utils/formValidation'
 import { empty } from '~utils/noop'
+import { FailedResponse, SuccessServiceAnswerResponse } from '~utils/response'
 
 export class UpdateServiceAnswerInteractor
 	implements Interactor<ServiceAnswerInput, ServiceAnswerResponse>
@@ -35,28 +32,22 @@ export class UpdateServiceAnswerInteractor
 
 	public async execute(input: ServiceAnswerInput): Promise<ServiceAnswerResponse> {
 		if (!input.id) {
-			return {
-				serviceAnswer: null,
-				message: this.#localization.t('mutation.updateServiceAnswers.answerIdRequired'),
-				status: StatusType.Failed
-			}
+			return new FailedResponse(
+				this.#localization.t('mutation.updateServiceAnswers.answerIdRequired')
+			)
 		}
 
 		const answer = await this.#serviceAnswers.itemById(input.id)
 		if (!answer.item) {
-			return {
-				serviceAnswer: null,
-				message: this.#localization.t('mutation.updateServiceAnswers.answerNotFound'),
-				status: StatusType.Failed
-			}
+			return new FailedResponse(
+				this.#localization.t('mutation.updateServiceAnswers.answerNotFound')
+			)
 		}
 		const service = await this.#services.itemById(answer.item.service_id)
 		if (!service.item) {
-			return {
-				serviceAnswer: null,
-				message: this.#localization.t('mutation.updateServiceAnswers.serviceNotFound'),
-				status: StatusType.Failed
-			}
+			return new FailedResponse(
+				this.#localization.t('mutation.updateServiceAnswers.serviceNotFound')
+			)
 		}
 
 		validateAnswer(service.item, input)
@@ -78,16 +69,13 @@ export class UpdateServiceAnswerInteractor
 
 		const dbAnswer = (await this.#serviceAnswers.itemById(input.id)).item!
 		if (!dbAnswer) {
-			return {
-				serviceAnswer: null,
-				message: this.#localization.t('mutation.updateServiceAnswers.serviceAnswerNotFound'),
-				status: StatusType.Failed
-			}
+			return new FailedResponse(
+				this.#localization.t('mutation.updateServiceAnswers.serviceAnswerNotFound')
+			)
 		}
-		return {
-			serviceAnswer: createGQLServiceAnswer(dbAnswer),
-			message: this.#localization.t('mutation.updateServiceAnswers.success'),
-			status: StatusType.Success
-		}
+		return new SuccessServiceAnswerResponse(
+			this.#localization.t('mutation.updateServiceAnswers.success'),
+			createGQLServiceAnswer(dbAnswer)
+		)
 	}
 }

--- a/packages/api/src/interactors/UpdateServiceAnswerInteractor.ts
+++ b/packages/api/src/interactors/UpdateServiceAnswerInteractor.ts
@@ -16,37 +16,27 @@ import { FailedResponse, SuccessServiceAnswerResponse } from '~utils/response'
 export class UpdateServiceAnswerInteractor
 	implements Interactor<ServiceAnswerInput, ServiceAnswerResponse>
 {
-	#localization: Localization
-	#services: ServiceCollection
-	#serviceAnswers: ServiceAnswerCollection
-
 	public constructor(
-		localization: Localization,
-		services: ServiceCollection,
-		serviceAnswers: ServiceAnswerCollection
-	) {
-		this.#localization = localization
-		this.#services = services
-		this.#serviceAnswers = serviceAnswers
-	}
+		private readonly localization: Localization,
+		private readonly services: ServiceCollection,
+		private readonly serviceAnswers: ServiceAnswerCollection
+	) {}
 
 	public async execute(input: ServiceAnswerInput): Promise<ServiceAnswerResponse> {
 		if (!input.id) {
 			return new FailedResponse(
-				this.#localization.t('mutation.updateServiceAnswers.answerIdRequired')
+				this.localization.t('mutation.updateServiceAnswers.answerIdRequired')
 			)
 		}
 
-		const answer = await this.#serviceAnswers.itemById(input.id)
+		const answer = await this.serviceAnswers.itemById(input.id)
 		if (!answer.item) {
-			return new FailedResponse(
-				this.#localization.t('mutation.updateServiceAnswers.answerNotFound')
-			)
+			return new FailedResponse(this.localization.t('mutation.updateServiceAnswers.answerNotFound'))
 		}
-		const service = await this.#services.itemById(answer.item.service_id)
+		const service = await this.services.itemById(answer.item.service_id)
 		if (!service.item) {
 			return new FailedResponse(
-				this.#localization.t('mutation.updateServiceAnswers.serviceNotFound')
+				this.localization.t('mutation.updateServiceAnswers.serviceNotFound')
 			)
 		}
 
@@ -54,7 +44,7 @@ export class UpdateServiceAnswerInteractor
 
 		//update the service answer
 		try {
-			await this.#serviceAnswers.updateItem(
+			await this.serviceAnswers.updateItem(
 				{ id: input.id },
 				{
 					$set: {
@@ -67,14 +57,14 @@ export class UpdateServiceAnswerInteractor
 			throw err
 		}
 
-		const dbAnswer = (await this.#serviceAnswers.itemById(input.id)).item!
+		const dbAnswer = (await this.serviceAnswers.itemById(input.id)).item!
 		if (!dbAnswer) {
 			return new FailedResponse(
-				this.#localization.t('mutation.updateServiceAnswers.serviceAnswerNotFound')
+				this.localization.t('mutation.updateServiceAnswers.serviceAnswerNotFound')
 			)
 		}
 		return new SuccessServiceAnswerResponse(
-			this.#localization.t('mutation.updateServiceAnswers.success'),
+			this.localization.t('mutation.updateServiceAnswers.success'),
 			createGQLServiceAnswer(dbAnswer)
 		)
 	}

--- a/packages/api/src/interactors/UpdateServiceInteractor.ts
+++ b/packages/api/src/interactors/UpdateServiceInteractor.ts
@@ -10,26 +10,23 @@ import { Interactor } from '~types'
 import { FailedResponse, SuccessServiceResponse } from '~utils/response'
 
 export class UpdateServiceInteractor implements Interactor<ServiceInput, ServiceResponse> {
-	#localization: Localization
-	#services: ServiceCollection
-
-	public constructor(localization: Localization, services: ServiceCollection) {
-		this.#localization = localization
-		this.#services = services
-	}
+	public constructor(
+		private readonly localization: Localization,
+		private readonly services: ServiceCollection
+	) {}
 
 	public async execute(service: ServiceInput): Promise<ServiceResponse> {
 		if (!service.id) {
-			return new FailedResponse(this.#localization.t('mutation.updateService.serviceIdRequired'))
+			return new FailedResponse(this.localization.t('mutation.updateService.serviceIdRequired'))
 		}
 
 		if (!service.orgId) {
-			return new FailedResponse(this.#localization.t('mutation.updateService.orgIdRequired'))
+			return new FailedResponse(this.localization.t('mutation.updateService.orgIdRequired'))
 		}
 
-		const result = await this.#services.itemById(service.id)
+		const result = await this.services.itemById(service.id)
 		if (!result.item) {
-			return new FailedResponse(this.#localization.t('mutation.updateService.serviceNotFound'))
+			return new FailedResponse(this.localization.t('mutation.updateService.serviceNotFound'))
 		}
 
 		const dbService = result.item
@@ -44,10 +41,10 @@ export class UpdateServiceInteractor implements Interactor<ServiceInput, Service
 			status: service.status || dbService.status
 		}
 
-		await this.#services.updateItem({ id: service.id }, { $set: changedData })
+		await this.services.updateItem({ id: service.id }, { $set: changedData })
 
 		return new SuccessServiceResponse(
-			this.#localization.t('mutation.updateService.success'),
+			this.localization.t('mutation.updateService.success'),
 			createGQLService(changedData)
 		)
 	}

--- a/packages/api/src/interactors/UpdateServiceInteractor.ts
+++ b/packages/api/src/interactors/UpdateServiceInteractor.ts
@@ -2,11 +2,12 @@
  * Copyright (c) Microsoft. All rights reserved.
  * Licensed under the MIT license. See LICENSE file in the project.
  */
-import { ServiceInput, ServiceResponse, StatusType } from '@cbosuite/schema/dist/provider-types'
+import { ServiceInput, ServiceResponse } from '@cbosuite/schema/dist/provider-types'
 import { Localization } from '~components'
 import { ServiceCollection } from '~db'
 import { createDBServiceFields, createGQLService } from '~dto'
 import { Interactor } from '~types'
+import { FailedResponse, SuccessServiceResponse } from '~utils/response'
 
 export class UpdateServiceInteractor implements Interactor<ServiceInput, ServiceResponse> {
 	#localization: Localization
@@ -19,28 +20,16 @@ export class UpdateServiceInteractor implements Interactor<ServiceInput, Service
 
 	public async execute(service: ServiceInput): Promise<ServiceResponse> {
 		if (!service.id) {
-			return {
-				service: null,
-				message: this.#localization.t('mutation.updateService.serviceIdRequired'),
-				status: StatusType.Failed
-			}
+			return new FailedResponse(this.#localization.t('mutation.updateService.serviceIdRequired'))
 		}
 
 		if (!service.orgId) {
-			return {
-				service: null,
-				message: this.#localization.t('mutation.updateService.orgIdRequired'),
-				status: StatusType.Failed
-			}
+			return new FailedResponse(this.#localization.t('mutation.updateService.orgIdRequired'))
 		}
 
 		const result = await this.#services.itemById(service.id)
 		if (!result.item) {
-			return {
-				service: null,
-				message: this.#localization.t('mutation.updateService.serviceNotFound'),
-				status: StatusType.Failed
-			}
+			return new FailedResponse(this.#localization.t('mutation.updateService.serviceNotFound'))
 		}
 
 		const dbService = result.item
@@ -57,10 +46,9 @@ export class UpdateServiceInteractor implements Interactor<ServiceInput, Service
 
 		await this.#services.updateItem({ id: service.id }, { $set: changedData })
 
-		return {
-			service: createGQLService(changedData),
-			message: this.#localization.t('mutation.updateService.success'),
-			status: StatusType.Success
-		}
+		return new SuccessServiceResponse(
+			this.#localization.t('mutation.updateService.success'),
+			createGQLService(changedData)
+		)
 	}
 }

--- a/packages/api/src/interactors/UpdateTagInteractor.ts
+++ b/packages/api/src/interactors/UpdateTagInteractor.ts
@@ -2,12 +2,13 @@
  * Copyright (c) Microsoft. All rights reserved.
  * Licensed under the MIT license. See LICENSE file in the project.
  */
-import { OrgTagInput, StatusType, TagResponse } from '@cbosuite/schema/dist/provider-types'
+import { OrgTagInput, TagResponse } from '@cbosuite/schema/dist/provider-types'
 import { Localization } from '~components'
 import { TagCollection } from '~db'
 import { createGQLTag } from '~dto'
 import { Interactor } from '~types'
 import { createLogger } from '~utils'
+import { FailedResponse, SuccessTagResponse } from '~utils/response'
 const logger = createLogger('interactors:update-tag')
 
 export class UpdateTagInteractor implements Interactor<OrgTagInput, TagResponse> {
@@ -22,11 +23,7 @@ export class UpdateTagInteractor implements Interactor<OrgTagInput, TagResponse>
 	public async execute(body: OrgTagInput): Promise<TagResponse> {
 		const { tag } = body
 		if (!tag.id) {
-			return {
-				tag: null,
-				message: this.#localization.t('mutation.updateTag.tagIdRequired'),
-				status: StatusType.Failed
-			}
+			return new FailedResponse(this.#localization.t('mutation.updateTag.tagIdRequired'))
 		}
 
 		// Update the tag
@@ -44,19 +41,15 @@ export class UpdateTagInteractor implements Interactor<OrgTagInput, TagResponse>
 		} catch (error) {
 			logger('failed to update tag', error)
 			// TODO send updateTag error to client
-			return {
-				status: StatusType.Failed,
-				message: this.#localization.t('mutation.updateTag.failed')
-			}
+			return new FailedResponse(this.#localization.t('mutation.updateTag.failed'))
 		}
 
 		// Get the updated tag from the database
 		const { item: updatedTag } = await this.#tags.itemById(tag.id)
 
-		return {
-			tag: createGQLTag(updatedTag!),
-			message: this.#localization.t('mutation.updateTag.success'),
-			status: StatusType.Success
-		}
+		return new SuccessTagResponse(
+			this.#localization.t('mutation.updateTag.success'),
+			createGQLTag(updatedTag!)
+		)
 	}
 }

--- a/packages/api/src/interactors/UpdateTagInteractor.ts
+++ b/packages/api/src/interactors/UpdateTagInteractor.ts
@@ -12,23 +12,23 @@ import { FailedResponse, SuccessTagResponse } from '~utils/response'
 const logger = createLogger('interactors:update-tag')
 
 export class UpdateTagInteractor implements Interactor<OrgTagInput, TagResponse> {
-	#localization: Localization
-	#tags: TagCollection
-
-	public constructor(localization: Localization, tags: TagCollection) {
-		this.#localization = localization
-		this.#tags = tags
+	public constructor(
+		private readonly localization: Localization,
+		private readonly tags: TagCollection
+	) {
+		this.localization = localization
+		this.tags = tags
 	}
 
 	public async execute(body: OrgTagInput): Promise<TagResponse> {
 		const { tag } = body
 		if (!tag.id) {
-			return new FailedResponse(this.#localization.t('mutation.updateTag.tagIdRequired'))
+			return new FailedResponse(this.localization.t('mutation.updateTag.tagIdRequired'))
 		}
 
 		// Update the tag
 		try {
-			await this.#tags.updateItem(
+			await this.tags.updateItem(
 				{ id: tag.id },
 				{
 					$set: {
@@ -41,14 +41,14 @@ export class UpdateTagInteractor implements Interactor<OrgTagInput, TagResponse>
 		} catch (error) {
 			logger('failed to update tag', error)
 			// TODO send updateTag error to client
-			return new FailedResponse(this.#localization.t('mutation.updateTag.failed'))
+			return new FailedResponse(this.localization.t('mutation.updateTag.failed'))
 		}
 
 		// Get the updated tag from the database
-		const { item: updatedTag } = await this.#tags.itemById(tag.id)
+		const { item: updatedTag } = await this.tags.itemById(tag.id)
 
 		return new SuccessTagResponse(
-			this.#localization.t('mutation.updateTag.success'),
+			this.localization.t('mutation.updateTag.success'),
 			createGQLTag(updatedTag!)
 		)
 	}

--- a/packages/api/src/interactors/UpdateTagInteractor.ts
+++ b/packages/api/src/interactors/UpdateTagInteractor.ts
@@ -40,7 +40,6 @@ export class UpdateTagInteractor implements Interactor<OrgTagInput, TagResponse>
 			)
 		} catch (error) {
 			logger('failed to update tag', error)
-			// TODO send updateTag error to client
 			return new FailedResponse(this.localization.t('mutation.updateTag.failed'))
 		}
 

--- a/packages/api/src/interactors/UpdateUserFCMTokenInteractor.ts
+++ b/packages/api/src/interactors/UpdateUserFCMTokenInteractor.ts
@@ -11,24 +11,21 @@ import { FailedResponse, SuccessVoidResponse } from '~utils/response'
 const logger = createLogger('interactors:update-user-fcm-token')
 
 export class UpdateUserFCMTokenInteractor implements Interactor<UserFcmInput, VoidResponse> {
-	#localization: Localization
-	#users: UserCollection
-
-	public constructor(localization: Localization, users: UserCollection) {
-		this.#localization = localization
-		this.#users = users
-	}
+	public constructor(
+		private readonly localization: Localization,
+		private readonly users: UserCollection
+	) {}
 
 	public async execute(body: UserFcmInput, { identity }: RequestContext): Promise<VoidResponse> {
 		if (!body?.fcmToken) {
 			return new FailedResponse(
-				this.#localization.t('mutation.updateUserFCMToken.userFCMTokenFailed')
+				this.localization.t('mutation.updateUserFCMToken.userFCMTokenFailed')
 			)
 		}
 
 		// TODO: tokenize and expire fcm tokens
 		try {
-			await this.#users.updateItem(
+			await this.users.updateItem(
 				{ id: identity?.id },
 				{
 					$set: {
@@ -39,10 +36,10 @@ export class UpdateUserFCMTokenInteractor implements Interactor<UserFcmInput, Vo
 		} catch (error) {
 			logger('error updating token', error)
 			return new FailedResponse(
-				this.#localization.t('mutation.updateUserFCMToken.userFCMTokenFailed')
+				this.localization.t('mutation.updateUserFCMToken.userFCMTokenFailed')
 			)
 		}
 
-		return new SuccessVoidResponse(this.#localization.t('mutation.updateUserFCMToken.success'))
+		return new SuccessVoidResponse(this.localization.t('mutation.updateUserFCMToken.success'))
 	}
 }

--- a/packages/api/src/interactors/UpdateUserFCMTokenInteractor.ts
+++ b/packages/api/src/interactors/UpdateUserFCMTokenInteractor.ts
@@ -2,11 +2,12 @@
  * Copyright (c) Microsoft. All rights reserved.
  * Licensed under the MIT license. See LICENSE file in the project.
  */
-import { StatusType, UserFcmInput, VoidResponse } from '@cbosuite/schema/dist/provider-types'
+import { UserFcmInput, VoidResponse } from '@cbosuite/schema/dist/provider-types'
 import { Localization } from '~components'
 import { UserCollection } from '~db'
 import { Interactor, RequestContext } from '~types'
 import { createLogger } from '~utils'
+import { FailedResponse, SuccessVoidResponse } from '~utils/response'
 const logger = createLogger('interactors:update-user-fcm-token')
 
 export class UpdateUserFCMTokenInteractor implements Interactor<UserFcmInput, VoidResponse> {
@@ -19,11 +20,11 @@ export class UpdateUserFCMTokenInteractor implements Interactor<UserFcmInput, Vo
 	}
 
 	public async execute(body: UserFcmInput, { identity }: RequestContext): Promise<VoidResponse> {
-		if (!body?.fcmToken)
-			return {
-				message: this.#localization.t('mutation.updateUserFCMToken.userFCMTokenFailed'),
-				status: StatusType.Failed
-			}
+		if (!body?.fcmToken) {
+			return new FailedResponse(
+				this.#localization.t('mutation.updateUserFCMToken.userFCMTokenFailed')
+			)
+		}
 
 		// TODO: tokenize and expire fcm tokens
 		try {
@@ -37,15 +38,11 @@ export class UpdateUserFCMTokenInteractor implements Interactor<UserFcmInput, Vo
 			)
 		} catch (error) {
 			logger('error updating token', error)
-			return {
-				message: this.#localization.t('mutation.updateUserFCMToken.userFCMTokenFailed'),
-				status: StatusType.Failed
-			}
+			return new FailedResponse(
+				this.#localization.t('mutation.updateUserFCMToken.userFCMTokenFailed')
+			)
 		}
 
-		return {
-			message: this.#localization.t('mutation.updateUserFCMToken.success'),
-			status: StatusType.Success
-		}
+		return new SuccessVoidResponse(this.#localization.t('mutation.updateUserFCMToken.success'))
 	}
 }

--- a/packages/api/src/interactors/UpdateUserInteractor.ts
+++ b/packages/api/src/interactors/UpdateUserInteractor.ts
@@ -2,11 +2,12 @@
  * Copyright (c) Microsoft. All rights reserved.
  * Licensed under the MIT license. See LICENSE file in the project.
  */
-import { StatusType, UserInput, UserResponse } from '@cbosuite/schema/dist/provider-types'
+import { UserInput, UserResponse } from '@cbosuite/schema/dist/provider-types'
 import { Localization } from '~components'
 import { DbRole, UserCollection } from '~db'
 import { createGQLUser } from '~dto'
 import { Interactor } from '~types'
+import { FailedResponse, SuccessUserResponse } from '~utils/response'
 
 export class UpdateUserInteractor implements Interactor<UserInput, UserResponse> {
 	#localization: Localization
@@ -19,21 +20,13 @@ export class UpdateUserInteractor implements Interactor<UserInput, UserResponse>
 
 	public async execute(user: UserInput): Promise<UserResponse> {
 		if (!user.id) {
-			return {
-				user: null,
-				message: this.#localization.t('mutation.updateUser.userIdRequired'),
-				status: StatusType.Failed
-			}
+			return new FailedResponse(this.#localization.t('mutation.updateUser.userIdRequired'))
 		}
 
 		const result = await this.#users.itemById(user.id)
 
 		if (!result.item) {
-			return {
-				user: null,
-				message: this.#localization.t('mutation.updateUser.userNotFound'),
-				status: StatusType.Failed
-			}
+			return new FailedResponse(this.#localization.t('mutation.updateUser.userNotFound'))
 		}
 		const dbUser = result.item
 
@@ -43,11 +36,7 @@ export class UpdateUserInteractor implements Interactor<UserInput, UserResponse>
 			})
 
 			if (emailCheck !== 0) {
-				return {
-					user: null,
-					message: this.#localization.t('mutation.updateUser.emailExist'),
-					status: StatusType.Failed
-				}
+				return new FailedResponse(this.#localization.t('mutation.updateUser.emailExist'))
 			}
 		}
 
@@ -83,10 +72,9 @@ export class UpdateUserInteractor implements Interactor<UserInput, UserResponse>
 			}
 		)
 
-		return {
-			user: createGQLUser(dbUser),
-			message: this.#localization.t('mutation.updateUser.success'),
-			status: StatusType.Success
-		}
+		return new SuccessUserResponse(
+			this.#localization.t('mutation.updateUser.success'),
+			createGQLUser(dbUser)
+		)
 	}
 }

--- a/packages/api/src/interactors/UpdateUserInteractor.ts
+++ b/packages/api/src/interactors/UpdateUserInteractor.ts
@@ -10,37 +10,34 @@ import { Interactor } from '~types'
 import { FailedResponse, SuccessUserResponse } from '~utils/response'
 
 export class UpdateUserInteractor implements Interactor<UserInput, UserResponse> {
-	#localization: Localization
-	#users: UserCollection
-
-	public constructor(localization: Localization, users: UserCollection) {
-		this.#localization = localization
-		this.#users = users
-	}
+	public constructor(
+		private readonly localization: Localization,
+		private readonly users: UserCollection
+	) {}
 
 	public async execute(user: UserInput): Promise<UserResponse> {
 		if (!user.id) {
-			return new FailedResponse(this.#localization.t('mutation.updateUser.userIdRequired'))
+			return new FailedResponse(this.localization.t('mutation.updateUser.userIdRequired'))
 		}
 
-		const result = await this.#users.itemById(user.id)
+		const result = await this.users.itemById(user.id)
 
 		if (!result.item) {
-			return new FailedResponse(this.#localization.t('mutation.updateUser.userNotFound'))
+			return new FailedResponse(this.localization.t('mutation.updateUser.userNotFound'))
 		}
 		const dbUser = result.item
 
 		if (dbUser.email !== user.email) {
-			const emailCheck = await this.#users.count({
+			const emailCheck = await this.users.count({
 				email: user.email
 			})
 
 			if (emailCheck !== 0) {
-				return new FailedResponse(this.#localization.t('mutation.updateUser.emailExist'))
+				return new FailedResponse(this.localization.t('mutation.updateUser.emailExist'))
 			}
 		}
 
-		await this.#users.updateItem(
+		await this.users.updateItem(
 			{ id: dbUser.id },
 			{
 				$set: {
@@ -73,7 +70,7 @@ export class UpdateUserInteractor implements Interactor<UserInput, UserResponse>
 		)
 
 		return new SuccessUserResponse(
-			this.#localization.t('mutation.updateUser.success'),
+			this.localization.t('mutation.updateUser.success'),
 			createGQLUser(dbUser)
 		)
 	}

--- a/packages/api/src/interactors/ValidateResetUserPasswordTokenInteractor.ts
+++ b/packages/api/src/interactors/ValidateResetUserPasswordTokenInteractor.ts
@@ -31,7 +31,7 @@ export class ValidateResetUserPasswordTokenInteractor
 		const isValid = await this.authenticator.verifyPasswordResetToken(resetToken)
 
 		if (!isValid || resetToken !== user.item.forgot_password_token) {
-			await this.users.updateItem({ email: email }, { $unset: { forgot_password_token: '' } })
+			await this.users.updateItem({ email }, { $unset: { forgot_password_token: '' } })
 
 			return new FailedResponse(
 				this.localization.t('mutation.forgotUserPassword.invalidTokenExpired')

--- a/packages/api/src/interactors/ValidateResetUserPasswordTokenInteractor.ts
+++ b/packages/api/src/interactors/ValidateResetUserPasswordTokenInteractor.ts
@@ -3,53 +3,41 @@
  * Licensed under the MIT license. See LICENSE file in the project.
  */
 import {
-	ForgotUserPasswordResponse,
+	VoidResponse,
 	ValidateResetUserPasswordTokenInput
 } from '@cbosuite/schema/dist/provider-types'
 import { Authenticator, Localization } from '~components'
 import { UserCollection } from '~db'
 import { Interactor } from '~types'
-import { FailedResponse, SuccessForgotUserPasswordResponse } from '~utils/response'
+import { FailedResponse, SuccessVoidResponse } from '~utils/response'
 
 export class ValidateResetUserPasswordTokenInteractor
-	implements Interactor<ValidateResetUserPasswordTokenInput, ForgotUserPasswordResponse>
+	implements Interactor<ValidateResetUserPasswordTokenInput, VoidResponse>
 {
-	#localization: Localization
-	#authenticator: Authenticator
-	#users: UserCollection
-
 	public constructor(
-		localization: Localization,
-		authenticator: Authenticator,
-		users: UserCollection
-	) {
-		this.#localization = localization
-		this.#authenticator = authenticator
-		this.#users = users
-	}
+		private readonly localization: Localization,
+		private readonly authenticator: Authenticator,
+		private readonly users: UserCollection
+	) {}
 
-	public async execute(
-		body: ValidateResetUserPasswordTokenInput
-	): Promise<ForgotUserPasswordResponse> {
+	public async execute(body: ValidateResetUserPasswordTokenInput): Promise<VoidResponse> {
 		const { email, resetToken } = body
-		const user = await this.#users.item({ email })
+		const user = await this.users.item({ email })
 
 		if (!user.item) {
-			return new FailedResponse(this.#localization.t('mutation.forgotUserPassword.userNotFound'))
+			return new FailedResponse(this.localization.t('mutation.forgotUserPassword.userNotFound'))
 		}
 
-		const isValid = await this.#authenticator.verifyPasswordResetToken(resetToken)
+		const isValid = await this.authenticator.verifyPasswordResetToken(resetToken)
 
 		if (!isValid || resetToken !== user.item.forgot_password_token) {
-			await this.#users.updateItem({ email: email }, { $unset: { forgot_password_token: '' } })
+			await this.users.updateItem({ email: email }, { $unset: { forgot_password_token: '' } })
 
 			return new FailedResponse(
-				this.#localization.t('mutation.forgotUserPassword.invalidTokenExpired')
+				this.localization.t('mutation.forgotUserPassword.invalidTokenExpired')
 			)
 		}
 
-		return new SuccessForgotUserPasswordResponse(
-			this.#localization.t('mutation.forgotUserPassword.success')
-		)
+		return new SuccessVoidResponse(this.localization.t('mutation.forgotUserPassword.success'))
 	}
 }

--- a/packages/api/src/locales/en-US/mutation.json
+++ b/packages/api/src/locales/en-US/mutation.json
@@ -334,5 +334,11 @@
     "_serviceNotFound.comment": "Service not found error message",
     "success": "Success",
     "_success.comment": "Success message"
+  },
+  "notifier": {
+    "assignedRequestTitle": "A client needs your help!",
+    "_assignedRequestTitle.comment": "Notification title when a user is being assigned a client",
+    "assignedRequestBody": "Got to the dashboard to view this request",
+    "_assignedRequestBody.comment": "Notification body when a user is being assigned a client"
   }
 }

--- a/packages/api/src/resolvers/Query/index.ts
+++ b/packages/api/src/resolvers/Query/index.ts
@@ -94,24 +94,14 @@ export const Query: QueryResolvers<AppContext> = {
 			.map(createGQLEngagement)
 	},
 	exportData: async (_, { body }, context) => {
-		const result = await context.collections.engagements.items(
-			{},
-			{
-				org_id: body.orgId
-			}
-		)
+		const result = await context.collections.engagements.items({}, { org_id: body.orgId })
 
 		return result.items
 			.sort((a, b) => sortByDate({ date: a.start_date }, { date: b.start_date }))
 			.map(createGQLEngagement)
 	},
 	services: async (_, { body }, context) => {
-		const result = await context.collections.services.items(
-			{},
-			{
-				org_id: body.orgId
-			}
-		)
+		const result = await context.collections.services.items({}, { org_id: body.orgId })
 
 		return result.items.map(createGQLService)
 	},

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -15,7 +15,6 @@ import {
 	EngagementResponse,
 	EngagementUserInput,
 	ForgotUserPasswordInput,
-	ForgotUserPasswordResponse,
 	MentionUserInput,
 	OrgTagInput,
 	PasswordChangeInput,
@@ -24,7 +23,6 @@ import {
 	ServiceAnswerInput,
 	ServiceResponse,
 	TagResponse,
-	UserActionResponse,
 	UserFcmInput,
 	UserIdInput,
 	UserInput,
@@ -82,14 +80,11 @@ export interface BuiltAppContext {
 		completeEngagement: Interactor<EngagementIdInput, EngagementResponse>
 		setEngagementStatus: Interactor<EngagementIdInput, EngagementResponse>
 		addEngagement: Interactor<EngagementActionInput, EngagementResponse>
-		forgotUserPassword: Interactor<ForgotUserPasswordInput, ForgotUserPasswordResponse>
-		validateResetUserPasswordToken: Interactor<
-			ValidateResetUserPasswordTokenInput,
-			ForgotUserPasswordResponse
-		>
-		changeUserPassword: Interactor<ChangeUserPasswordInput, ForgotUserPasswordResponse>
-		resetUserPassword: Interactor<UserIdInput, UserActionResponse>
-		setUserPassword: Interactor<PasswordChangeInput, UserActionResponse>
+		forgotUserPassword: Interactor<ForgotUserPasswordInput, VoidResponse>
+		validateResetUserPasswordToken: Interactor<ValidateResetUserPasswordTokenInput, VoidResponse>
+		changeUserPassword: Interactor<ChangeUserPasswordInput, VoidResponse>
+		resetUserPassword: Interactor<UserIdInput, UserResponse>
+		setUserPassword: Interactor<PasswordChangeInput, UserResponse>
 		createNewUser: Interactor<UserInput, UserResponse>
 		deleteUser: Interactor<UserIdInput, VoidResponse>
 		updateUser: Interactor<UserInput, UserResponse>

--- a/packages/api/src/utils/response.ts
+++ b/packages/api/src/utils/response.ts
@@ -8,7 +8,6 @@ import {
 	ContactResponse,
 	Engagement,
 	EngagementResponse,
-	ForgotUserPasswordResponse,
 	StatusType,
 	User,
 	VoidResponse,
@@ -66,16 +65,6 @@ export class SuccessAuthenticationResponse
 		super(message)
 	}
 }
-
-export class SuccessForgotUserPasswordResponse
-	extends SuccessResponse
-	implements ForgotUserPasswordResponse
-{
-	public constructor(message: string) {
-		super(message)
-	}
-}
-
 export class SuccessContactResponse extends SuccessResponse implements ContactResponse {
 	public constructor(message: string, public contact: Contact) {
 		super(message)

--- a/packages/api/src/utils/response.ts
+++ b/packages/api/src/utils/response.ts
@@ -1,0 +1,107 @@
+/*!
+ * Copyright (c) Microsoft. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project.
+ */
+
+import {
+	AuthenticationResponse,
+	ContactResponse,
+	Engagement,
+	EngagementResponse,
+	ForgotUserPasswordResponse,
+	StatusType,
+	User,
+	VoidResponse,
+	Contact,
+	TagResponse,
+	Tag,
+	UserResponse,
+	ServiceAnswerResponse,
+	ServiceAnswer,
+	Service,
+	ServiceResponse
+} from '@cbosuite/schema/dist/provider-types'
+
+export class BaseResponse {
+	public constructor(private _message: string, private _status: StatusType) {}
+
+	public get message() {
+		return this._message
+	}
+
+	public get status() {
+		return this._status
+	}
+}
+
+export class SuccessResponse extends BaseResponse {
+	public constructor(message: string) {
+		super(message, StatusType.Success)
+	}
+}
+
+export class FailedResponse extends BaseResponse {
+	public constructor(message: string) {
+		super(message, StatusType.Failed)
+	}
+}
+
+export class SuccessVoidResponse extends SuccessResponse implements VoidResponse {
+	public constructor(message: string) {
+		super(message)
+	}
+}
+
+export class SuccessEngagementResponse extends SuccessResponse implements EngagementResponse {
+	public constructor(message: string, public engagement: Engagement) {
+		super(message)
+	}
+}
+
+export class SuccessAuthenticationResponse
+	extends SuccessResponse
+	implements AuthenticationResponse
+{
+	public constructor(message: string, public user: User, public token: string | null) {
+		super(message)
+	}
+}
+
+export class SuccessForgotUserPasswordResponse
+	extends SuccessResponse
+	implements ForgotUserPasswordResponse
+{
+	public constructor(message: string) {
+		super(message)
+	}
+}
+
+export class SuccessContactResponse extends SuccessResponse implements ContactResponse {
+	public constructor(message: string, public contact: Contact) {
+		super(message)
+	}
+}
+
+export class SuccessTagResponse extends SuccessResponse implements TagResponse {
+	public constructor(message: string, public tag: Tag) {
+		super(message)
+	}
+}
+
+export class SuccessUserResponse extends SuccessResponse implements UserResponse {
+	public constructor(message: string, public user: User) {
+		super(message)
+	}
+}
+
+export class SuccessServiceAnswerResponse extends SuccessResponse implements ServiceAnswerResponse {
+	public constructor(message: string, public serviceAnswer: ServiceAnswer) {
+		super(message)
+	}
+}
+
+export class SuccessServiceResponse extends SuccessResponse implements ServiceResponse {
+	public constructor(message: string, public service: Service) {
+		super(message)
+	}
+}

--- a/packages/api/src/utils/response.ts
+++ b/packages/api/src/utils/response.ts
@@ -61,7 +61,7 @@ export class SuccessAuthenticationResponse
 	extends SuccessResponse
 	implements AuthenticationResponse
 {
-	public constructor(message: string, public user: User, public token: string | null) {
+	public constructor(message: string, public user: User, public accessToken: string | null) {
 		super(message)
 	}
 }

--- a/packages/schema/schema.gql
+++ b/packages/schema/schema.gql
@@ -80,19 +80,17 @@ type Mutation {
 	#
 	# Forgot password
 	#
-	forgotUserPassword(body: ForgotUserPasswordInput!): ForgotUserPasswordResponse!
+	forgotUserPassword(body: ForgotUserPasswordInput!): VoidResponse!
 
 	#
 	# Validate Forgot password token / key
 	#
-	validateResetUserPasswordToken(
-		body: ValidateResetUserPasswordTokenInput!
-	): ForgotUserPasswordResponse!
+	validateResetUserPasswordToken(body: ValidateResetUserPasswordTokenInput!): VoidResponse!
 
 	#
 	# Change password after Validate Forgot password token / key, this endpoint is unauthenticated
 	#
-	changeUserPassword(body: ChangeUserPasswordInput!): ForgotUserPasswordResponse!
+	changeUserPassword(body: ChangeUserPasswordInput!): VoidResponse!
 
 	#
 	# Assign an Engagement
@@ -122,12 +120,12 @@ type Mutation {
 	#
 	# Reset user password
 	#
-	resetUserPassword(body: UserIdInput!): UserActionResponse @auth
+	resetUserPassword(body: UserIdInput!): UserResponse @auth
 
 	#
 	# Allow user to set password
 	#
-	setUserPassword(body: PasswordChangeInput!): UserActionResponse @auth
+	setUserPassword(body: PasswordChangeInput!): UserResponse @auth
 
 	#
 	# Add engagement action
@@ -261,25 +259,6 @@ enum StatusType {
 type VoidResponse {
 	#
 	# An error or status message regarding the attempted request
-	#
-	message: String!
-
-	#
-	# Response status
-	#
-	status: StatusType!
-}
-#
-# General response type for user related actions
-#
-type UserActionResponse {
-	#
-	# The user that has been authenticated; possibly null
-	#
-	user: User
-
-	#
-	# An error or status message regarding the authentication attempt
 	#
 	message: String!
 
@@ -1178,11 +1157,6 @@ input ServiceAnswerIdInput {
 input ChangeUserPasswordInput {
 	email: String!
 	newPassword: String!
-}
-
-type ForgotUserPasswordResponse {
-	status: StatusType!
-	message: String
 }
 
 enum ServiceFieldType {

--- a/packages/webapp/src/hooks/api/useAuth/useChangePasswordCallback.ts
+++ b/packages/webapp/src/hooks/api/useAuth/useChangePasswordCallback.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT license. See LICENSE file in the project.
  */
 import { gql, useMutation } from '@apollo/client'
-import { ForgotUserPasswordResponse, StatusType } from '@cbosuite/schema/dist/client-types'
+import { VoidResponse, StatusType } from '@cbosuite/schema/dist/client-types'
 import { MessageResponse } from '../types'
 import { useCallback } from 'react'
 
@@ -33,7 +33,7 @@ export function useChangePasswordCallback(): ChangeUserPasswordResetCallback {
 
 			try {
 				const resp = await changeUserPassword({ variables: { body: { email, newPassword } } })
-				const changeUserPasswordResp = resp.data.changeUserPassword as ForgotUserPasswordResponse
+				const changeUserPasswordResp = resp.data.changeUserPassword as VoidResponse
 				if (changeUserPasswordResp?.status === StatusType.Success) {
 					result.status = StatusType.Success
 				}

--- a/packages/webapp/src/hooks/api/useAuth/useForgotPasswordCallback.ts
+++ b/packages/webapp/src/hooks/api/useAuth/useForgotPasswordCallback.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT license. See LICENSE file in the project.
  */
 import { gql, useMutation } from '@apollo/client'
-import { ForgotUserPasswordResponse, StatusType } from '@cbosuite/schema/dist/client-types'
+import { VoidResponse, StatusType } from '@cbosuite/schema/dist/client-types'
 import { MessageResponse } from '../types'
 import { createLogger } from '~utils/createLogger'
 import { useCallback } from 'react'
@@ -28,7 +28,7 @@ export function useForgotPasswordCallback(): ForgotUserPasswordCallback {
 
 			try {
 				const resp = await forgotUserPassword({ variables: { body: { email } } })
-				const forgotUserPasswordResp = resp.data.forgotUserPassword as ForgotUserPasswordResponse
+				const forgotUserPasswordResp = resp.data.forgotUserPassword as VoidResponse
 				if (forgotUserPasswordResp?.status === StatusType.Success) {
 					result.status = StatusType.Success
 				}

--- a/packages/webapp/src/hooks/api/useAuth/useResetPasswordCallback.ts
+++ b/packages/webapp/src/hooks/api/useAuth/useResetPasswordCallback.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT license. See LICENSE file in the project.
  */
 import { gql, useMutation } from '@apollo/client'
-import { StatusType, UserActionResponse } from '@cbosuite/schema/dist/client-types'
+import { StatusType, UserResponse } from '@cbosuite/schema/dist/client-types'
 import { CurrentUserFields } from '../fragments'
 import { useToasts } from '~hooks/useToasts'
 import { useTranslation } from '~hooks/useTranslation'
@@ -39,7 +39,7 @@ export function useResetPasswordCallback(): ResetPasswordCallback {
 
 			try {
 				const resp = await resetUserPassword({ variables: { body: { userId } } })
-				const resetUserPasswordResp = resp.data.resetUserPassword as UserActionResponse
+				const resetUserPasswordResp = resp.data.resetUserPassword as UserResponse
 				if (resetUserPasswordResp?.status === StatusType.Success) {
 					result.status = StatusType.Success
 					success(c('hooks.useAuth.resetSuccess'))

--- a/packages/webapp/src/hooks/api/useAuth/useValidatePasswordResetCallback.ts
+++ b/packages/webapp/src/hooks/api/useAuth/useValidatePasswordResetCallback.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT license. See LICENSE file in the project.
  */
 import { gql, useMutation } from '@apollo/client'
-import { ForgotUserPasswordResponse, StatusType } from '@cbosuite/schema/dist/client-types'
+import { VoidResponse, StatusType } from '@cbosuite/schema/dist/client-types'
 import { createLogger } from '~utils/createLogger'
 import { MessageResponse } from '../types'
 import { useCallback } from 'react'
@@ -33,7 +33,7 @@ export function useValidateResetPasswordCallback(): ValidateUserPasswordResetCal
 					variables: { body: { email, resetToken } }
 				})
 				const validateResetPasswordTokenResp = resp.data
-					.validateResetUserPasswordToken as ForgotUserPasswordResponse
+					.validateResetUserPasswordToken as VoidResponse
 				if (validateResetPasswordTokenResp?.status === StatusType.Success) {
 					result.status = StatusType.Success
 				}

--- a/packages/webapp/src/hooks/api/useProfile/useSetPasswordCallback.ts
+++ b/packages/webapp/src/hooks/api/useProfile/useSetPasswordCallback.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT license. See LICENSE file in the project.
  */
 import { gql, useMutation } from '@apollo/client'
-import { StatusType, UserActionResponse } from '@cbosuite/schema/dist/client-types'
+import { StatusType, UserResponse } from '@cbosuite/schema/dist/client-types'
 import { useCallback } from 'react'
 import { useToasts } from '~hooks/useToasts'
 import { useTranslation } from '~hooks/useTranslation'
@@ -40,7 +40,7 @@ export function useSetPasswordCallback(): SetPasswordCallback {
 
 			try {
 				const resp = await setUserPassword({ variables: { body: { oldPassword, newPassword } } })
-				const setUserPasswordResp = resp.data.setUserPassword as UserActionResponse
+				const setUserPasswordResp = resp.data.setUserPassword as UserResponse
 
 				if (setUserPasswordResp.status === StatusType.Success) {
 					result.status = StatusType.Success


### PR DESCRIPTION
* Use factory methods for creating response objects.
* Pack PubSub interaction behind a new `Publisher` component.
* Use TypeScript's private constructor mechanism instead of ES private field syntax