### PR TITLE
Eliminate duplication in org->entity linkage

### DIFF
--- a/packages/api/migrations/20211023012131-remove_org_link_outs.ts
+++ b/packages/api/migrations/20211023012131-remove_org_link_outs.ts
@@ -1,0 +1,22 @@
+/*!
+ * Copyright (c) Microsoft. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project.
+ */
+
+import { Db, MongoClient } from 'mongodb'
+
+module.exports = {
+	async up(db: Db, client: MongoClient) {
+		// Drop tokens table
+		if (await db.listCollections({ name: 'user_tokens' }).hasNext()) {
+			const tokens = db.collection('user_tokens')
+			await tokens.drop()
+		}
+
+		// Drop fan-outs, query related tables with org_id criteria instead
+		const orgs = db.collection('organizations')
+		await orgs.updateMany({}, { $unset: { users: 1, contacts: 1, tags: 1 } })
+	},
+
+	async down(db: Db, client: MongoClient) {}
+}

--- a/packages/api/src/components/AppContextProvider.ts
+++ b/packages/api/src/components/AppContextProvider.ts
@@ -213,26 +213,15 @@ export class AppContextProvider implements AsyncProvider<BuiltAppContext> {
 					userCollection
 				),
 				setUserPassword: new SetUserPasswordInteractor(localization, userCollection),
-				createNewUser: new CreateNewUserInteractor(
-					localization,
-					mailer,
-					userCollection,
-					orgCollection,
-					config
-				),
-				deleteUser: new DeleteUserInteractor(
-					localization,
-					userCollection,
-					orgCollection,
-					engagementCollection
-				),
+				createNewUser: new CreateNewUserInteractor(localization, mailer, userCollection, config),
+				deleteUser: new DeleteUserInteractor(localization, userCollection, engagementCollection),
 				updateUser: new UpdateUserInteractor(localization, userCollection),
 				updateUserFCMToken: new UpdateUserFCMTokenInteractor(localization, userCollection),
 				markMentionSeen: new MarkMentionSeenInteractor(localization, userCollection),
 				markMentionDismissed: new MarkMentionDismissedInteractor(localization, userCollection),
-				createNewTag: new CreateNewTagInteractor(localization, tagCollection, orgCollection),
+				createNewTag: new CreateNewTagInteractor(localization, tagCollection),
 				updateTag: new UpdateTagInteractor(localization, tagCollection),
-				createContact: new CreateContactInteractor(localization, contactCollection, orgCollection),
+				createContact: new CreateContactInteractor(localization, contactCollection),
 				updateContact: new UpdateContactInteractor(localization, contactCollection),
 				archiveContact: new ArchiveContactInteractor(localization, contactCollection),
 				createService: new CreateServiceInteractor(localization, serviceCollection),

--- a/packages/api/src/db/ContactCollection.ts
+++ b/packages/api/src/db/ContactCollection.ts
@@ -5,4 +5,8 @@
 import { CollectionBase } from './CollectionBase'
 import type { DbContact } from './types'
 
-export class ContactCollection extends CollectionBase<DbContact> {}
+export class ContactCollection extends CollectionBase<DbContact> {
+	public findContactsWithOrganization(orgId: string, offset = 0, limit = 100) {
+		return this.items({ offset, limit }, { org_id: orgId })
+	}
+}

--- a/packages/api/src/db/TagCollection.ts
+++ b/packages/api/src/db/TagCollection.ts
@@ -5,4 +5,8 @@
 import { CollectionBase } from './CollectionBase'
 import type { DbTag } from './types'
 
-export class TagCollection extends CollectionBase<DbTag> {}
+export class TagCollection extends CollectionBase<DbTag> {
+	public findTagsWithOrganization(orgId: string, offset = 0, limit = 100) {
+		return this.items({ offset, limit }, { org_id: orgId })
+	}
+}

--- a/packages/api/src/db/UserCollection.ts
+++ b/packages/api/src/db/UserCollection.ts
@@ -46,4 +46,15 @@ export class UserCollection extends CollectionBase<DbUser> {
 			}
 		)
 	}
+
+	public findUsersWithOrganization(organizationId: string, offset = 0, limit = 50) {
+		return this.items(
+			{ offset, limit },
+			{
+				'roles.org_id': {
+					$eq: organizationId
+				}
+			}
+		)
+	}
 }

--- a/packages/api/src/interactors/CreateContactInteractor.ts
+++ b/packages/api/src/interactors/CreateContactInteractor.ts
@@ -4,7 +4,7 @@
  */
 import { MutationCreateContactArgs, ContactResponse } from '@cbosuite/schema/dist/provider-types'
 import { Localization } from '~components'
-import { ContactCollection, OrganizationCollection } from '~db'
+import { ContactCollection } from '~db'
 import { createGQLContact } from '~dto'
 import { createDBContact } from '~dto/createDBContact'
 import { Interactor } from '~types'
@@ -15,8 +15,7 @@ export class CreateContactInteractor
 {
 	public constructor(
 		private readonly localization: Localization,
-		private readonly contacts: ContactCollection,
-		private readonly orgs: OrganizationCollection
+		private readonly contacts: ContactCollection
 	) {}
 
 	public async execute({ contact }: MutationCreateContactArgs): Promise<ContactResponse> {
@@ -25,11 +24,7 @@ export class CreateContactInteractor
 		}
 
 		const newContact = createDBContact(contact)
-
-		await Promise.all([
-			this.contacts.insertItem(newContact),
-			this.orgs.updateItem({ id: newContact.org_id }, { $push: { contacts: newContact.id } })
-		])
+		await this.contacts.insertItem(newContact)
 
 		return new SuccessContactResponse(
 			this.localization.t('mutation.createContact.success'),

--- a/packages/api/src/interactors/CreateNewTagInteractor.ts
+++ b/packages/api/src/interactors/CreateNewTagInteractor.ts
@@ -4,7 +4,7 @@
  */
 import { MutationCreateNewTagArgs, TagResponse } from '@cbosuite/schema/dist/provider-types'
 import { Localization } from '~components'
-import { OrganizationCollection, TagCollection } from '~db'
+import { TagCollection } from '~db'
 import { createDBTag, createGQLTag } from '~dto'
 import { Interactor } from '~types'
 import { SuccessTagResponse } from '~utils/response'
@@ -12,8 +12,7 @@ import { SuccessTagResponse } from '~utils/response'
 export class CreateNewTagInteractor implements Interactor<MutationCreateNewTagArgs, TagResponse> {
 	public constructor(
 		private readonly localization: Localization,
-		private readonly tags: TagCollection,
-		private readonly orgs: OrganizationCollection
+		private readonly tags: TagCollection
 	) {}
 
 	public async execute({ tag }: MutationCreateNewTagArgs): Promise<TagResponse> {
@@ -21,12 +20,6 @@ export class CreateNewTagInteractor implements Interactor<MutationCreateNewTagAr
 
 		try {
 			await this.tags.insertItem(newTag)
-		} catch (err) {
-			throw err
-		}
-
-		try {
-			await this.orgs.updateItem({ id: newTag.org_id }, { $push: { tags: newTag.id } })
 		} catch (err) {
 			throw err
 		}

--- a/packages/api/src/interactors/CreateNewUserInteractor.ts
+++ b/packages/api/src/interactors/CreateNewUserInteractor.ts
@@ -20,7 +20,6 @@ export class CreateNewUserInteractor
 		private readonly localization: Localization,
 		private readonly mailer: Transporter,
 		private readonly users: UserCollection,
-		private readonly orgs: OrganizationCollection,
 		private readonly config: Configuration
 	) {}
 
@@ -44,10 +43,7 @@ export class CreateNewUserInteractor
 		// Create a dbabase object from input values
 		const newUser = createDBUser(user, password)
 
-		await Promise.all([
-			this.users.insertItem(newUser),
-			this.orgs.updateItem({ id: newUser.roles[0].org_id }, { $push: { users: newUser.id } })
-		])
+		await Promise.all([this.users.insertItem(newUser)])
 
 		let successMessage = this.localization.t('mutation.createNewUser.success')
 		const loginLink = `${this.config.origin}/login`

--- a/packages/api/src/interactors/DeleteUserInteractor.ts
+++ b/packages/api/src/interactors/DeleteUserInteractor.ts
@@ -4,7 +4,7 @@
  */
 import { MutationDeleteUserArgs, VoidResponse } from '@cbosuite/schema/dist/provider-types'
 import { Localization } from '~components'
-import { EngagementCollection, OrganizationCollection, UserCollection } from '~db'
+import { EngagementCollection, UserCollection } from '~db'
 import { Interactor, RequestContext } from '~types'
 import { FailedResponse, SuccessVoidResponse } from '~utils/response'
 
@@ -12,7 +12,6 @@ export class DeleteUserInteractor implements Interactor<MutationDeleteUserArgs, 
 	public constructor(
 		private readonly localization: Localization,
 		private readonly users: UserCollection,
-		private readonly orgs: OrganizationCollection,
 		private readonly engagements: EngagementCollection
 	) {}
 
@@ -74,20 +73,6 @@ export class DeleteUserInteractor implements Interactor<MutationDeleteUserArgs, 
 						)
 					}
 				}
-			}
-		} catch (error) {
-			return new FailedResponse(this.localization.t('mutation.deleteUser.fail'))
-		}
-
-		// Remove user from organization
-		try {
-			const orgWithUser = await this.orgs.item({ id: identity?.roles[0].org_id })
-			if (orgWithUser.item) {
-				const nextUsers = orgWithUser.item.users.filter((orgUserId) => orgUserId !== userId)
-				await this.orgs.updateItem(
-					{ id: identity?.roles[0].org_id },
-					{ $set: { users: nextUsers } }
-				)
 			}
 		} catch (error) {
 			return new FailedResponse(this.localization.t('mutation.deleteUser.fail'))


### PR DESCRIPTION
Currently, links are persisted two ways: orgs record what entities they are related to, and those entities persist an org_id field. This PR removes the first portion of this, relying on org_id fields in related entities as the source of truth.