### PR TITLE
Editable duration for new request

### DIFF
--- a/packages/webapp/src/components/forms/AddRequestForm/index.tsx
+++ b/packages/webapp/src/components/forms/AddRequestForm/index.tsx
@@ -77,7 +77,7 @@ export const AddRequestForm: StandardFC<AddRequestFormProps> = wrap(function Add
 					userId: null,
 					contactIds: [],
 					tags: null,
-					duration: 0,
+					duration: 1,
 					durationUnit: 'hour',
 					description: ''
 				}}
@@ -135,11 +135,10 @@ export const AddRequestForm: StandardFC<AddRequestFormProps> = wrap(function Add
 										<FormikField
 											name='duration'
 											type='number'
-											min='0'
-											max='999'
+											min={1}
+											max={999}
 											placeholder={t('addRequestFields.addDurationPlaceholder')}
 											className={cx(styles.field, 'duration')}
-											error={get(touched, 'duration') ? get(errors, 'duration') : undefined}
 										/>
 									</Col>
 									<Col className='mb-3 mb-md-0'>

--- a/packages/webapp/src/components/forms/AddRequestForm/index.tsx
+++ b/packages/webapp/src/components/forms/AddRequestForm/index.tsx
@@ -8,7 +8,7 @@ import cx from 'classnames'
 import { Formik, Form } from 'formik'
 import { Col, Row } from 'react-bootstrap'
 import * as yup from 'yup'
-import { REQUEST_DURATIONS, REQUEST_DURATION_UNITS } from '~constants'
+import { REQUEST_DURATION_UNITS } from '~constants'
 import { FormSectionTitle } from '~components/ui/FormSectionTitle'
 import { FormikSubmitButton } from '~components/ui/FormikSubmitButton'
 import type { StandardFC } from '~types/StandardFC'
@@ -47,7 +47,7 @@ export const AddRequestForm: StandardFC<AddRequestFormProps> = wrap(function Add
 			}
 		}
 	]
-	const durations = useMemo(() => REQUEST_DURATIONS.map((d) => ({ ...d, label: t(d.label) })), [t])
+
 	const durationUnits = useMemo(
 		() => REQUEST_DURATION_UNITS.map((d) => ({ ...d, label: t(d.label) })),
 		[t]

--- a/packages/webapp/src/components/ui/FormikField/index.tsx
+++ b/packages/webapp/src/components/ui/FormikField/index.tsx
@@ -20,6 +20,8 @@ interface FormikFieldProps {
 	type?: string
 	value?: string
 	disabled?: boolean
+	min?: number
+	max?: number
 	onChange?: (val: any) => void
 }
 

--- a/packages/webapp/src/constants/REQUEST_DURATIONS.ts
+++ b/packages/webapp/src/constants/REQUEST_DURATIONS.ts
@@ -20,3 +20,18 @@ export const REQUEST_DURATIONS = [
 		label: 'addRequestDurations.2weeks'
 	}
 ]
+
+export const REQUEST_DURATION_UNITS = [
+	{
+		value: 'hour',
+		label: 'addRequestDurationUnits.hour'
+	},
+	{
+		value: 'day',
+		label: 'addRequestDurationUnits.day'
+	},
+	{
+		value: 'week',
+		label: 'addRequestDurationUnits.week'
+	}
+]

--- a/packages/webapp/src/hooks/api/useEngagementList/addEngagementCallback.ts
+++ b/packages/webapp/src/hooks/api/useEngagementList/addEngagementCallback.ts
@@ -35,6 +35,20 @@ export function useAddEngagementCallback(): AddEngagementCallback {
 		async (engagementInput: EngagementInput) => {
 			const engagement = { ...engagementInput, orgId }
 			try {
+				if (engagement.duration) {
+					if (engagement.durationUnit?.length) {
+						if ('day' === engagement.durationUnit) {
+							engagement.duration = engagement.duration * 24
+						} else if ('week' === engagement.durationUnit) {
+							engagement.duration = engagement.duration * 168
+						}
+
+						delete engagement.durationUnit
+					}
+
+					engagement.duration = engagement.duration.toString()
+				}
+
 				// execute mutator
 				await createEngagement({
 					variables: { engagement }

--- a/packages/webapp/src/hooks/api/useEngagementList/addEngagementCallback.ts
+++ b/packages/webapp/src/hooks/api/useEngagementList/addEngagementCallback.ts
@@ -38,9 +38,9 @@ export function useAddEngagementCallback(): AddEngagementCallback {
 				if (engagement.duration) {
 					if (engagement['durationUnit']?.length) {
 						if ('day' === engagement['durationUnit']) {
-							engagement.duration = engagement['durationUnit'] * 24
+							engagement.duration = (parseInt(engagement.duration) * 24).toString()
 						} else if ('week' === engagement['durationUnit']) {
-							engagement.duration = engagement.duration * 168
+							engagement.duration = (parseInt(engagement.duration) * 168).toString()
 						}
 
 						delete engagement['durationUnit']

--- a/packages/webapp/src/hooks/api/useEngagementList/addEngagementCallback.ts
+++ b/packages/webapp/src/hooks/api/useEngagementList/addEngagementCallback.ts
@@ -36,14 +36,14 @@ export function useAddEngagementCallback(): AddEngagementCallback {
 			const engagement = { ...engagementInput, orgId }
 			try {
 				if (engagement.duration) {
-					if (engagement.durationUnit?.length) {
-						if ('day' === engagement.durationUnit) {
-							engagement.duration = engagement.duration * 24
-						} else if ('week' === engagement.durationUnit) {
+					if (engagement['durationUnit']?.length) {
+						if ('day' === engagement['durationUnit']) {
+							engagement.duration = engagement['durationUnit'] * 24
+						} else if ('week' === engagement['durationUnit']) {
 							engagement.duration = engagement.duration * 168
 						}
 
-						delete engagement.durationUnit
+						delete engagement['durationUnit']
 					}
 
 					engagement.duration = engagement.duration.toString()

--- a/packages/webapp/src/locales/en-US/requests.json
+++ b/packages/webapp/src/locales/en-US/requests.json
@@ -70,6 +70,10 @@
     "_addDuration.comment": "Add Duration field label",
     "addDurationPlaceholder": "Enter duration here...",
     "_addDurationPlaceholder.comment": "Placeholder text for Add Duration field",
+    "addDurationUnit": "Select Unit",
+    "_addDurationUnit.comment": "Select Duration Unit field label",
+    "addDurationUnitPlaceholder": "Select unit here...",
+    "_addDurationUnitPlaceholder.comment": "Placeholder text for Add Duration Unit field",
     "assignSpecialist": "Assign Specialist",
     "_assignSpecialist.comment": "Assign Specialist field label",
     "assignSpecialistPlaceholder": "Search or Create...",
@@ -102,6 +106,14 @@
     "_1week.comment": "Duration label for 1 week. {Placeholder = 1}",
     "2weeks": "2 weeks",
     "_2weeks.comment": "Duration label for 2 weeks. {Placeholder = 2}"
+  },
+  "addRequestDurationUnits": {
+    "hour": "Hour(s)",
+    "_hour.comment": "Duration label for hour unit.",
+    "day": "Day(s)",
+    "_day.comment": "Duration label for day unit.",
+    "week": "Week(s)",
+    "_week.comment": "Duration label for week unit."
   },
   "editRequestTitle": "Edit Request",
   "_editRequestTitle.comment": "Edit Request panel title",

--- a/packages/webapp/src/locales/es-US/requests.json
+++ b/packages/webapp/src/locales/es-US/requests.json
@@ -59,6 +59,11 @@
     "1week": "1 semana",
     "2weeks": "2 semanas"
   },
+  "addRequestDurationUnits": {
+    "hour": "Hora",
+    "day": "Día",
+    "week": "Semana"
+  },
   "editRequestTitle": "Editar solicitud",
   "editRequestFields": {
     "requestTitle": "Título de solicitud",


### PR DESCRIPTION
Split duration field into two separated fields. One text field for the number and one select for the unit (Hour, Day, Week). Converted back to number of hours on submission.