### PR TITLE
Remove shadow from footer

### DIFF
--- a/packages/webapp/src/components/ui/Footer/index.module.scss
+++ b/packages/webapp/src/components/ui/Footer/index.module.scss
@@ -5,66 +5,36 @@
 @use '~styles/lib/colors' as *;
 @use '~styles/lib/space' as *;
 
-.footerContainer {
-	padding: space(4);
-	display: flex;
-	flex-direction: column;
-	justify-content: center;
-	align-items: center;
+%footer {
 	background-color: color('white');
-	margin-top: space(7);
-	box-shadow: 0px space(2) space(3) color('text-dark');
+	border-top: 1px solid;
+	display: flex;
+	justify-content: center;
+	padding: space(4);
+
+	a {
+		color: color('dark');
+	}
 }
 
 .footer {
-	display: flex;
-	justify-content: center;
-	align-items: center;
-	background-color: color('white');
-	a div {
-		font-size: 12px;
+	@extend %footer;
+
+	& > *:not(:first-child) {
+		margin-left: space();
+
+		// Add a separator
+		&::before {
+			content: '|';
+			margin-right: space();
+		}
 	}
 }
 
 .footerMobile {
-	padding: space(4);
-	display: flex;
-	flex-direction: column;
-	justify-content: center;
+	@extend %footer;
+
 	align-items: center;
-	background-color: color('white');
-	box-shadow: 0px space(2) space(3) color('text-dark');
-	//margin-top: space(8);
-
-	a div {
-		font-size: 8px;
-	}
-}
-
-.link {
-	cursor: pointer;
-	margin-left: space();
-	margin-right: space();
-	display: flex;
-	align-content: center;
-	color: color('dark');
-}
-
-.pilotContactEmail {
-	font-weight: bold;
-	color: color('primary-light');
-}
-
-.pilotLinkWrapper {
-	display: flex;
-	flex-direction: row;
-	margin-bottom: space();
-}
-
-.pilotLinkWrapperMobile {
-	display: flex;
 	flex-direction: column;
-	align-items: center;
-	justify-content: center;
-	margin-bottom: space();
+	gap: 1em;
 }

--- a/packages/webapp/src/components/ui/Footer/index.tsx
+++ b/packages/webapp/src/components/ui/Footer/index.tsx
@@ -11,84 +11,37 @@ import { constants } from '~utils/features'
 import { useWindowSize } from '~hooks/useWindowSize'
 
 export const Footer: StandardFC = memo(function Footer(_props) {
-	const dims = useWindowSize()
-	return dims.isLessThanLG ? <FooterMobile /> : <FooterDesktop />
-})
-
-function FooterMobile() {
-	return (
-		<>
-			<div className={styles.footerMobile}>
-				<FooterLinks />
-			</div>
-		</>
-	)
-}
-
-function FooterDesktop() {
-	return (
-		<div className={styles.footerContainer}>
-			<div className={styles.footer}>
-				<FooterLinks join={' | '} />
-			</div>
-		</div>
-	)
-}
-
-const FooterLinks: FC<{ join?: string }> = memo(function FooterLinks({ join }) {
 	const { t } = useTranslation(Namespace.Footer)
+	const classname = useWindowSize().isLessThanLG ? styles.footerMobile : styles.footer
+
 	const links = [
-		constants.privacyUrl ? (
-			<Link key='privacy' href={constants.privacyUrl}>
+		!!constants.privacyUrl && (
+			<a key='privacy' href={constants.privacyUrl} rel='noreferrer'>
 				{t('footerBar.privacyAndCookies')}
-			</Link>
-		) : null,
-		constants.trademarksUrl ? (
-			<Link key='trademarks' href={constants.trademarksUrl}>
+			</a>
+		),
+		!!constants.trademarksUrl && (
+			<a key='trademarks' href={constants.trademarksUrl} rel='noreferrer'>
 				{t('footerBar.trademarks')}
-			</Link>
-		) : null,
-		constants.termsOfUseUrl ? (
-			<Link key='termsofuse' href={constants.termsOfUseUrl}>
+			</a>
+		),
+		!!constants.termsOfUseUrl && (
+			<a key='termsofuse' href={constants.termsOfUseUrl} rel='noreferrer'>
 				{t('footerBar.termsOfUse')}
-			</Link>
-		) : null,
-		constants.contactUsEmail ? (
-			<Link key='contactus' href={`mailto:${constants.contactUsEmail}`}>
+			</a>
+		),
+		!!constants.contactUsEmail && (
+			<a key='contactus' href={`mailto:${constants.contactUsEmail}`} rel='noreferrer'>
 				{t('footerBar.contactUs')}
-			</Link>
-		) : null,
-		constants.codeOfConductUrl ? (
-			<Link key='codeofconduct' href={constants.codeOfConductUrl}>
+			</a>
+		),
+		!!constants.codeOfConductUrl && (
+			<a key='codeofconduct' href={constants.codeOfConductUrl} rel='noreferrer'>
 				{t('footerBar.codeOfConduct')}
-			</Link>
-		) : null,
-		constants.copyright ? <Link key='copyright'>{constants.copyright}</Link> : null
-	].filter((t) => !!t)
-	const elements: Array<JSX.Element | string> = []
-	for (let i = 0; i < links.length; i++) {
-		elements.push(links[i])
-		if (i < links.length - 1) {
-			elements.push(join)
-		}
-	}
-	return <>{elements}</>
-})
+			</a>
+		),
+		constants.copyright && <span key='copyright'>{constants.copyright}</span>
+	].filter((link) => !!link)
 
-const Link: FC<{
-	href?: string
-	className?: string
-	style?: CSSProperties
-}> = memo(function Link({ className, children, href, style }) {
-	const finalClassName = classnames(styles.link, { className })
-
-	return href == null ? (
-		<div style={style} className={finalClassName}>
-			{children}
-		</div>
-	) : (
-		<a target='_blank' rel='noreferrer' href={href} style={style} className={finalClassName}>
-			{children}
-		</a>
-	)
+	return <footer className={classname}>{links}</footer>
 })

--- a/packages/webapp/src/components/ui/Footer/index.tsx
+++ b/packages/webapp/src/components/ui/Footer/index.tsx
@@ -2,8 +2,7 @@
  * Copyright (c) Microsoft. All rights reserved.
  * Licensed under the MIT license. See LICENSE file in the project.
  */
-import { memo, FC, CSSProperties } from 'react'
-import classnames from 'classnames'
+import { memo } from 'react'
 import styles from './index.module.scss'
 import type { StandardFC } from '~types/StandardFC'
 import { Namespace, useTranslation } from '~hooks/useTranslation'


### PR DESCRIPTION
**Why**
- Fix #302 
- Was confusing to the user.

**What**
- Remove the `shadow-box` CSS property.
- Added a `border-top` to visually delimit the footer.
- Improve spacing for tap area on touchscreens.

**How**
- Refactor the components from 5 to 1.
- Refactor stylesheet.