### PR TITLE
Clients: Rename field from "Additional tags" to just "Tags"

### DIFF
--- a/packages/webapp/src/locales/en-US/clients.json
+++ b/packages/webapp/src/locales/en-US/clients.json
@@ -75,7 +75,7 @@
       "_statePlaceHolder.comment": "Placeholder for state address field",
       "zipCodePlaceholder": "Zip Code",
       "_zipCodePlaceholder.comment": "Placeholder for zip code address field",
-      "tags": "Additional Tags",
+      "tags": "Tags",
       "_tags.comment": "Tags field label",
       "addTagsPlaceholder": "Add tags...",
       "_addTagsPlaceholder.comment": "Placeholder for add tags field"
@@ -130,7 +130,7 @@
       "_statePlaceHolder.comment": "Placeholder for state address field",
       "zipCodePlaceholder": "Zip Code",
       "_zipCodePlaceholder.comment": "Placeholder for zip code address field",
-      "tags": "Additional Tags",
+      "tags": "Tags",
       "_tags.comment": "Tags field label",
       "addTagsPlaceholder": "Add tags...",
       "_addTagsPlaceholder.comment": "Placeholder for add tags field"


### PR DESCRIPTION
**Why**
 - fix #327

**What**
- Update the `en-US` locale file to reflect copy change request

**Screenshot**

![Screen Shot 2022-02-15 at 13 53 24](https://user-images.githubusercontent.com/636801/154129502-38f735c5-347a-4145-860b-843792447688.png)

