### PR TITLE
add description field label to create request form

### DIFF
--- a/packages/webapp/src/components/forms/AddRequestForm/index.tsx
+++ b/packages/webapp/src/components/forms/AddRequestForm/index.tsx
@@ -224,6 +224,13 @@ export const AddRequestForm: StandardFC<AddRequestFormProps> = wrap(function Add
 
 								<Row className='mb-4 pb-2'>
 									<Col>
+										<FormSectionTitle>
+											<>
+												{t('addRequestFields.description')}{' '}
+												<span className='text-normal'>({t('addRequestFields.optional')})</span>
+											</>
+										</FormSectionTitle>
+
 										<ActionInput
 											name='description'
 											error={get(touched, 'description') ? get(errors, 'description') : undefined}

--- a/packages/webapp/src/locales/en-US/requests.json
+++ b/packages/webapp/src/locales/en-US/requests.json
@@ -103,6 +103,7 @@
     "addTagPlaceholder": "Add tag...",
     "_addTagPlaceholder.comment": "Placeholder text for add tag",
     "description": "Description",
+    "_description.comment": "Description field label",
     "optional": "Optional",
     "_optional.comment": "Optional field label text"
   },

--- a/packages/webapp/src/locales/en-US/requests.json
+++ b/packages/webapp/src/locales/en-US/requests.json
@@ -102,6 +102,7 @@
     "_assignSpecialistPlaceholder.comment": "Placeholder text for Assign Specialist",
     "addTagPlaceholder": "Add tag...",
     "_addTagPlaceholder.comment": "Placeholder text for add tag",
+    "description": "Description",
     "optional": "Optional",
     "_optional.comment": "Optional field label text"
   },


### PR DESCRIPTION
I've added the requested label for the description field,  I've gone with "description" here as the label to match the already existing label in the edit component.

*Note:*
Translation here is required for `addRequestFields.description`

Fixes: #318 