### PR TITLE
Request Details Panel Description Label

### DIFF
--- a/packages/webapp/src/components/ui/RequestPanelBody/index.tsx
+++ b/packages/webapp/src/components/ui/RequestPanelBody/index.tsx
@@ -119,6 +119,9 @@ export const RequestPanelBody: StandardFC<RequestPanelBodyProps> = memo(function
 				</Row>
 
 				{/* Request description */}
+				<div className='d-inline-block'>
+					<strong>{t('viewRequest.body.description')}</strong>
+				</div>
 				<div className='mb-4'>
 					<ShortString text={description} limit={240} />
 				</div>

--- a/packages/webapp/src/locales/en-US/requests.json
+++ b/packages/webapp/src/locales/en-US/requests.json
@@ -191,6 +191,8 @@
       "_assignedTo.comment": "Label for Assigned to",
       "assignToPlaceholder": "Assign to specialist...",
       "_assignToPlaceholder.comment": "Placeholder for Assign to field",
+      "description": "Description",
+      "_description.comment": "Description field label",
       "openStatus": "Open",
       "_openStatus.comment": "Label for Request with Open status",
       "dateCreated": "Date created",


### PR DESCRIPTION
Fixes #322

Added a label to the description section of the request details panel.

Note: added two keys to the en-us local files.

![image](https://user-images.githubusercontent.com/20339669/154149467-2515a6da-0e67-42d1-9bd8-7e64da9a9901.png)
