### PR TITLE
Bug/331 modal sheet close button is sometimes blocked by fields

### DIFF
--- a/packages/webapp/src/components/forms/AddClientForm/index.tsx
+++ b/packages/webapp/src/components/forms/AddClientForm/index.tsx
@@ -198,7 +198,6 @@ export const AddClientForm: StandardFC<AddClientFormProps> = wrap(function AddCl
 												border: '1px solid var(--bs-gray-4)',
 												borderRadius: '3px',
 												minHeight: '35px',
-												//paddingTop: 4,
 												selectors: {
 													'.ms-TextField-fieldGroup': {
 														border: 0,
@@ -224,10 +223,11 @@ export const AddClientForm: StandardFC<AddClientFormProps> = wrap(function AddCl
 												}
 											}
 										}}
-										className={cx(styles.field)}
+										className={styles.field}
 									/>
 								</Col>
 							</Row>
+
 							<FormSectionTitle>{t('addClient.fields.addContactInfo')}</FormSectionTitle>
 							<Row className='mb-4 pb-2'>
 								<Col>
@@ -247,6 +247,7 @@ export const AddClientForm: StandardFC<AddClientFormProps> = wrap(function AddCl
 									/>
 								</Col>
 							</Row>
+
 							<FormSectionTitle>{t('addClient.fields.address')}</FormSectionTitle>
 							<Row>
 								<Col md={8}>
@@ -390,6 +391,7 @@ export const AddClientForm: StandardFC<AddClientFormProps> = wrap(function AddCl
 									/>
 								</Col>
 							</Row>
+
 							<FormikSubmitButton
 								className='btnAddClientSubmit'
 								disabled={!values.firstName || !values.lastName}
@@ -397,9 +399,7 @@ export const AddClientForm: StandardFC<AddClientFormProps> = wrap(function AddCl
 								{t('addClient.buttons.createClient')}
 							</FormikSubmitButton>
 							{submitMessage && (
-								<div className={cx('mt-5 alert alert-danger')}>
-									{t('addClient.submitMessage.failed')}
-								</div>
+								<div className='mt-5 alert alert-danger'>{t('addClient.submitMessage.failed')}</div>
 							)}
 						</Form>
 					)

--- a/packages/webapp/src/components/forms/EditRequestForm/index.tsx
+++ b/packages/webapp/src/components/forms/EditRequestForm/index.tsx
@@ -117,7 +117,7 @@ export const EditRequestForm: StandardFC<EditRequestFormProps> = wrap(function E
 										name='title'
 										placeholder={t('editRequestFields.requestTitlePlaceholder')}
 										className={cx(styles.field)}
-										error={errors.title.toString()}
+										error={errors?.title?.toString()}
 										errorClassName={cx(styles.errorLabel)}
 									/>
 								</Col>

--- a/packages/webapp/src/components/layouts/ContainerLayout/index.module.scss
+++ b/packages/webapp/src/components/layouts/ContainerLayout/index.module.scss
@@ -4,14 +4,6 @@
  */
 @use '~styles/lib/space' as *;
 
-.actionBar {
-	min-height: space(5);
-	position: sticky;
-	top: 0px;
-	height: 58px;
-	z-index: 1;
-}
-
 .content {
 	min-height: 91vh;
 }

--- a/packages/webapp/src/components/layouts/ContainerLayout/index.tsx
+++ b/packages/webapp/src/components/layouts/ContainerLayout/index.tsx
@@ -19,9 +19,7 @@ export const ContainerLayout: FC = wrap(function ContainerLayout({ children }) {
 
 	return (
 		<>
-			<div className={styles.actionBar}>
-				<ActionBar showNav showTitle title={organization?.name} showPersona showNotifications />
-			</div>
+			<ActionBar showNav showTitle title={organization?.name} showPersona showNotifications />
 			<FlyoutPanels />
 			<CRC className={styles.content}>
 				{currentUser?.id ? (

--- a/packages/webapp/src/components/ui/ActionBar/index.module.scss
+++ b/packages/webapp/src/components/ui/ActionBar/index.module.scss
@@ -5,8 +5,10 @@
 @use '~styles/lib/space' as *;
 
 .actionBar {
-	min-height: space(5);
-	height: 58px;
+	height: var(--action-bar--height);
+	min-height: var(--action-bar--height);
+	position: sticky;
+	top: 0px;
 	z-index: 1;
 
 	a {

--- a/packages/webapp/src/components/ui/ContactPanel/index.tsx
+++ b/packages/webapp/src/components/ui/ContactPanel/index.tsx
@@ -43,10 +43,10 @@ export const ContactPanel: StandardFC<ContactPanelProps> = memo(function Contact
 				}}
 				styles={{
 					main: {
-						marginTop: 58
+						marginTop: 'var(--action-bar--height)'
 					},
 					overlay: {
-						marginTop: 58
+						marginTop: 'var(--action-bar--height)'
 					},
 					contentInner: {
 						marginTop: -44

--- a/packages/webapp/src/components/ui/LanguageDropdown/index.tsx
+++ b/packages/webapp/src/components/ui/LanguageDropdown/index.tsx
@@ -140,10 +140,10 @@ function useDropdownStyle() {
 			subComponentStyles: {
 				panel: {
 					main: {
-						marginTop: 58
+						marginTop: 'var(--action-bar--height)'
 					},
 					overlay: {
-						marginTop: 58
+						marginTop: 'var(--action-bar--height)'
 					}
 				}
 			}

--- a/packages/webapp/src/components/ui/NewFormPanel/NewFormPanel.tsx
+++ b/packages/webapp/src/components/ui/NewFormPanel/NewFormPanel.tsx
@@ -12,12 +12,14 @@ import { QuickActionsPanelBody } from '~components/ui/QuickActionsPanelBody'
 import { ServiceListPanelBody } from '~components/ui/ServiceListPanelBody'
 import { noop } from '~utils/noop'
 
-export const NewFormPanel: FC<{
+interface NewFormPanelProps {
 	showNewFormPanel?: boolean
 	newFormPanelName?: string
 	onNewFormPanelSubmit?: (values: any, formName?: string) => void
 	onNewFormPanelDismiss?: () => void
-}> = memo(function NewFormPanel({
+}
+
+export const NewFormPanel: FC<NewFormPanelProps> = memo(function NewFormPanel({
 	showNewFormPanel = false,
 	newFormPanelName,
 	onNewFormPanelSubmit = noop,

--- a/packages/webapp/src/components/ui/NotificationsPanel/index.tsx
+++ b/packages/webapp/src/components/ui/NotificationsPanel/index.tsx
@@ -36,10 +36,10 @@ export const NotificationPanel: StandardFC<NotificationPanelProps> = memo(
 
 const panelStyles: Partial<IPanelStyles> = {
 	main: {
-		marginTop: 58
+		marginTop: 'var(--action-bar--height)'
 	},
 	overlay: {
-		marginTop: 58
+		marginTop: 'var(--action-bar--height)'
 	},
 	contentInner: {
 		marginTop: -44

--- a/packages/webapp/src/components/ui/Panel/index.tsx
+++ b/packages/webapp/src/components/ui/Panel/index.tsx
@@ -4,10 +4,8 @@
  */
 import { IPanelStyles, Panel as FluentPanel, PanelType } from '@fluentui/react'
 import { useBoolean } from '@fluentui/react-hooks'
-import cx from 'classnames'
 import { memo, useEffect } from 'react'
 import type { StandardFC } from '~types/StandardFC'
-import { IconButton } from '~ui/IconButton'
 import { noop } from '~utils/noop'
 
 interface PanelProps {

--- a/packages/webapp/src/components/ui/Panel/index.tsx
+++ b/packages/webapp/src/components/ui/Panel/index.tsx
@@ -43,6 +43,7 @@ export const Panel: StandardFC<PanelProps> = memo(function Panel({
 	)
 })
 
+// Source: https://developer.microsoft.com/en-us/fluentui#/controls/web/panel#IPanelStyles
 const panelStyles: Partial<IPanelStyles> = {
 	main: {
 		marginTop: 'var(--action-bar--height)'
@@ -50,6 +51,9 @@ const panelStyles: Partial<IPanelStyles> = {
 	overlay: {
 		marginTop: 'var(--action-bar--height)',
 		cursor: 'default'
+	},
+	commands: {
+		zIndex: '1'
 	},
 	scrollableContent: {
 		minHeight: '100%'

--- a/packages/webapp/src/components/ui/Panel/index.tsx
+++ b/packages/webapp/src/components/ui/Panel/index.tsx
@@ -2,28 +2,21 @@
  * Copyright (c) Microsoft. All rights reserved.
  * Licensed under the MIT license. See LICENSE file in the project.
  */
-import { Panel as FluentPanel, PanelType } from '@fluentui/react'
+import { IPanelStyles, Panel as FluentPanel, PanelType } from '@fluentui/react'
 import { useBoolean } from '@fluentui/react-hooks'
 import cx from 'classnames'
-import { isEmpty } from 'lodash'
 import { memo, useEffect } from 'react'
-import styles from './index.module.scss'
 import type { StandardFC } from '~types/StandardFC'
 import { IconButton } from '~ui/IconButton'
 import { noop } from '~utils/noop'
 
 interface PanelProps {
-	openPanel?: boolean
 	onDismiss?: () => void
-	buttonOptions?: {
-		label: string
-		icon: string
-	}
+	openPanel?: boolean
 }
 
 export const Panel: StandardFC<PanelProps> = memo(function Panel({
 	children,
-	buttonOptions,
 	onDismiss = noop,
 	openPanel = false
 }) {
@@ -33,63 +26,58 @@ export const Panel: StandardFC<PanelProps> = memo(function Panel({
 		openPanel ? openFluentPanel() : dismissPanel()
 	}, [dismissPanel, openFluentPanel, openPanel])
 
+	const handleOnDismiss = () => {
+		onDismiss()
+		dismissPanel()
+	}
+
 	return (
-		<div className={cx(styles.wrapper)}>
-			{buttonOptions && !isEmpty(buttonOptions) && (
-				<IconButton
-					icon={buttonOptions.icon}
-					onClick={openFluentPanel}
-					text={buttonOptions.label}
-				/>
-			)}
-			<FluentPanel
-				isLightDismiss={false}
-				isOpen={isOpen}
-				type={PanelType.medium}
-				closeButtonAriaLabel='Close'
-				onDismiss={() => {
-					onDismiss()
-					dismissPanel()
-				}}
-				styles={{
-					main: {
-						marginTop: 58
-					},
-					overlay: {
-						marginTop: 58,
-						cursor: 'default'
-					},
-					scrollableContent: {
-						minHeight: '100%'
-					},
-					content: {
-						minHeight: '100%'
-					},
-					subComponentStyles: {
-						closeButton: {
-							root: {
-								backgroundColor: 'var(--bs-primary-light)',
-								borderRadius: '50%',
-								marginRight: 20,
-								width: 26,
-								height: 26
-							},
-							rootHovered: {
-								backgroundColor: 'var(--bs-primary-light)'
-							},
-							rootPressed: {
-								backgroundColor: 'var(--bs-primary-light)'
-							},
-							icon: {
-								color: 'var(--bs-white)',
-								fontWeight: 600
-							}
-						}
-					}
-				}}
-			>
-				<div className={styles.body}>{children}</div>
-			</FluentPanel>
-		</div>
+		<FluentPanel
+			closeButtonAriaLabel='Close'
+			isLightDismiss={false}
+			isOpen={isOpen}
+			onDismiss={handleOnDismiss}
+			type={PanelType.medium}
+			styles={panelStyles}
+		>
+			{children}
+		</FluentPanel>
 	)
 })
+
+const panelStyles: Partial<IPanelStyles> = {
+	main: {
+		marginTop: 'var(--action-bar--height)'
+	},
+	overlay: {
+		marginTop: 'var(--action-bar--height)',
+		cursor: 'default'
+	},
+	scrollableContent: {
+		minHeight: '100%'
+	},
+	content: {
+		minHeight: '100%'
+	},
+	subComponentStyles: {
+		closeButton: {
+			root: {
+				backgroundColor: 'var(--bs-primary-light)',
+				borderRadius: '50%',
+				marginRight: 20,
+				width: 26,
+				height: 26
+			},
+			rootHovered: {
+				backgroundColor: 'var(--bs-primary-light)'
+			},
+			rootPressed: {
+				backgroundColor: 'var(--bs-primary-light)'
+			},
+			icon: {
+				color: 'var(--bs-white)',
+				fontWeight: 600
+			}
+		}
+	}
+}

--- a/packages/webapp/src/components/ui/RequestPanel/index.module.scss
+++ b/packages/webapp/src/components/ui/RequestPanel/index.module.scss
@@ -7,7 +7,6 @@
 .loadingSpinner {
 	position: absolute;
 	background: color('white');
-	//min-height: calc(100vh - 58px);
 	height: 100%;
 	width: 100%;
 	z-index: 1;
@@ -18,7 +17,6 @@
 
 .loaded {
 	animation: fadeOut 0.5s forwards;
-	//animation-delay: 0.5s;
 }
 
 @keyframes fadeOut {

--- a/packages/webapp/src/components/ui/RequestPanel/index.tsx
+++ b/packages/webapp/src/components/ui/RequestPanel/index.tsx
@@ -39,10 +39,10 @@ export const RequestPanel: StandardFC<RequestPanelProps> = memo(function Request
 				onDismiss={onDismiss}
 				styles={{
 					main: {
-						marginTop: 58
+						marginTop: 'var(--action-bar--height)'
 					},
 					overlay: {
-						marginTop: 58
+						marginTop: 'var(--action-bar--height)'
 					},
 					contentInner: {
 						marginTop: -44

--- a/packages/webapp/src/components/ui/SpecialistPanel/index.tsx
+++ b/packages/webapp/src/components/ui/SpecialistPanel/index.tsx
@@ -53,10 +53,10 @@ export const SpecialistPanel: StandardFC<SpecialistPanelProps> = memo(function S
 
 const panelStyles: Partial<IPanelStyles> = {
 	main: {
-		marginTop: 58
+		marginTop: 'var(--action-bar--height)'
 	},
 	overlay: {
-		marginTop: 58
+		marginTop: 'var(--action-bar--height)'
 	},
 	contentInner: {
 		marginTop: -44

--- a/packages/webapp/src/index.tsx
+++ b/packages/webapp/src/index.tsx
@@ -4,6 +4,7 @@
  */
 import '~styles/bootstrap.custom.scss'
 import '~styles/App_reset_styles.scss'
+import '~styles/variables.css'
 import { mount } from './mount'
 
 mount()

--- a/packages/webapp/src/styles/variables.css
+++ b/packages/webapp/src/styles/variables.css
@@ -1,0 +1,4 @@
+:root {
+	/* Action bar */
+	--action-bar--height: 60px;
+}


### PR DESCRIPTION
**Why**
- Fix #331 

**What**
- By using CSS as JSON FluentUI typed passed as a prop.
- For some reason, the date picker is some sort of z-index.
- Adding a `z-index` to the header of the panel solve the issue.

**Also**
- Clean up a bit some components as I went and one small bug.
- Removed the _ActionBar_ `height` set in hard value in 6 files, to a CSS custom property.

**Issue**
- This hack is the only thing I can do, as I cannot edit the _FluentUI_ component.

**Screenshot**

https://user-images.githubusercontent.com/636801/154353333-9a9d1e62-582d-4a7b-845a-d725775dadf2.mov


