### PR TITLE
remove request description field minimum limit

### DIFF
--- a/packages/webapp/src/components/forms/RequestActionForm/index.tsx
+++ b/packages/webapp/src/components/forms/RequestActionForm/index.tsx
@@ -29,7 +29,6 @@ export const RequestActionForm: StandardFC<FormProps> = wrap(function RequestAct
 
 	const RequestActionFormSchema = Yup.object().shape({
 		comment: Yup.string()
-			.min(2, t('viewRequest.body.yup.tooShort'))
 			.max(50, t('viewRequest.body.yup.tooLong'))
 			.required(t('viewRequest.body.yup.required'))
 	})


### PR DESCRIPTION
Removes the minimum character limit from the request description field

Fixes: #320 