### PR TITLE
Fix issue with search on Service page

### DIFF
--- a/packages/webapp/src/hooks/useServiceSearchHandler.ts
+++ b/packages/webapp/src/hooks/useServiceSearchHandler.ts
@@ -11,8 +11,8 @@ export function useServiceSearchHandler(items: Service[], onFilter: (filted: Ser
 		const contains = (value: string): boolean =>
 			!!value?.toLowerCase()?.includes(search?.toLowerCase())
 
-		const inName = service?.name && contains(service.name)
-		const inDescription = service?.description && contains(service.description)
+		const inName = contains(service?.name)
+		const inDescription = contains(service?.description)
 		const inTags = service?.tags?.some((tag: Tag) => contains(tag.label))
 
 		return inName || inDescription || inTags

--- a/packages/webapp/src/hooks/useServiceSearchHandler.ts
+++ b/packages/webapp/src/hooks/useServiceSearchHandler.ts
@@ -7,12 +7,16 @@ import { Service, Tag } from '@cbosuite/schema/dist/client-types'
 import { useSearchHandler } from './useSearchHandler'
 
 export function useServiceSearchHandler(items: Service[], onFilter: (filted: Service[]) => void) {
-	return useSearchHandler(
-		items,
-		onFilter,
-		(s: Service, search: string) =>
-			s.name.toLowerCase().includes(search.toLowerCase()) ||
-			s.description.toLowerCase().includes(search.toLowerCase()) ||
-			s.tags?.some((t: Tag) => t.label.toLowerCase().includes(search.toLowerCase()))
-	)
+	function predicate(service: Service, search: string) {
+		const contains = (value: string): boolean =>
+			!!value?.toLowerCase()?.includes(search?.toLowerCase())
+
+		const inName = service?.name && contains(service.name)
+		const inDescription = service?.description && contains(service.description)
+		const inTags = service?.tags?.some((tag: Tag) => contains(tag.label))
+
+		return inName || inDescription || inTags
+	}
+
+	return useSearchHandler(items, onFilter, predicate)
 }


### PR DESCRIPTION
**What**
- fix #329 
- The search broke on the service page

**How**
- Added some _optional chaining_ in case a value being search was null

**Video**

https://user-images.githubusercontent.com/636801/156652738-852c6d44-8401-45e5-b2a8-a71f59091110.mov

