### PR TITLE
Clients: add a notes field

### DIFF
--- a/packages/api/src/db/types.ts
+++ b/packages/api/src/db/types.ts
@@ -104,7 +104,7 @@ export interface DbContact {
 	tags?: string[]
 	status?: ContactStatus
 	demographics: DbContactDemographics
-	notes: string
+	notes?: string
 }
 
 export interface DbContactDemographics {

--- a/packages/api/src/db/types.ts
+++ b/packages/api/src/db/types.ts
@@ -104,6 +104,7 @@ export interface DbContact {
 	tags?: string[]
 	status?: ContactStatus
 	demographics: DbContactDemographics
+	notes: string
 }
 
 export interface DbContactDemographics {

--- a/packages/api/src/dto/createDBContact.ts
+++ b/packages/api/src/dto/createDBContact.ts
@@ -40,6 +40,7 @@ export function createDBContact(contact: ContactInput): DbContact {
 			preferred_contact_time: contact.demographics?.preferredContactTime || ''
 		},
 		tags: contact?.tags || undefined,
-		status: contact?.status || ContactStatus.Active
+		status: contact?.status || ContactStatus.Active,
+		notes: contact?.notes || ''
 	}
 }

--- a/packages/api/src/dto/createGQLContact.ts
+++ b/packages/api/src/dto/createGQLContact.ts
@@ -37,6 +37,7 @@ export function createGQLContact(contact: DbContact): Contact {
 			preferredLanguage: contact.demographics?.preferred_language || '',
 			preferredLanguageOther: contact.demographics?.preferred_language_other || '',
 			preferredContactTime: contact.demographics?.preferred_contact_time || ''
-		}
+		},
+		notes: contact?.notes || ''
 	}
 }

--- a/packages/api/src/interactors/mutation/UpdateContactInteractor.ts
+++ b/packages/api/src/interactors/mutation/UpdateContactInteractor.ts
@@ -75,7 +75,8 @@ export class UpdateContactInteractor
 				preferred_language_other: contact.demographics?.preferredLanguageOther || emptyStr,
 				preferred_contact_time: contact.demographics?.preferredContactTime || emptyStr
 			},
-			tags: contact?.tags || undefined
+			tags: contact?.tags || undefined,
+			notes: contact?.notes || emptyStr
 		}
 
 		await this.contacts.updateItem({ id: dbContact.id }, { $set: changedData })

--- a/packages/schema/schema.gql
+++ b/packages/schema/schema.gql
@@ -807,6 +807,11 @@ type Contact {
 	# Demographics of the contact
 	#
 	demographics: Demographics
+
+	#
+	# Notes related to the contact
+	#
+	notes: String
 }
 
 type Demographics {
@@ -895,6 +900,11 @@ input ContactInput {
 	# The contact demographics
 	#
 	demographics: DemographicsInput
+
+	#
+	# Notes related to the contact
+	#
+	notes: String
 }
 
 type ContactResponse {

--- a/packages/webapp/src/components/forms/AddClientForm/index.tsx
+++ b/packages/webapp/src/components/forms/AddClientForm/index.tsx
@@ -95,7 +95,8 @@ export const AddClientForm: StandardFC<AddClientFormProps> = wrap(function AddCl
 				ethnicityOther:
 					values.ethnicity === lastEthnicityOption.key ? values.ethnicityCustom : emptyStr
 			},
-			tags: values?.tags ? values.tags.map((a) => a.value) : undefined
+			tags: values?.tags ? values.tags.map((a) => a.value) : undefined,
+			notes: values?.notes
 		}
 
 		const response = await createContact(newContact)
@@ -125,6 +126,7 @@ export const AddClientForm: StandardFC<AddClientFormProps> = wrap(function AddCl
 					state: '',
 					zip: '',
 					tags: [],
+					notes: '',
 					gender: '',
 					genderCustom: '',
 					ethnicity: '',
@@ -282,6 +284,17 @@ export const AddClientForm: StandardFC<AddClientFormProps> = wrap(function AddCl
 									<TagSelect name='tags' placeholder={t('addClient.fields.addTagsPlaceholder')} />
 								</Col>
 							</Row>
+
+							<FormSectionTitle>{t('addClient.fields.notes')}</FormSectionTitle>
+							<FormikField
+								as='textarea'
+								autoComplete='off'
+								name='notes'
+								placeholder={t('addClient.fields.notesPlaceholder')}
+								className={styles.field}
+								error={errors.notes}
+								errorClassName={styles.errorLabel}
+							/>
 
 							{/* Demographics */}
 							<Row className='mb-4 pb-2 flex-col flex-md-row'>

--- a/packages/webapp/src/components/forms/EditClientForm/index.tsx
+++ b/packages/webapp/src/components/forms/EditClientForm/index.tsx
@@ -141,7 +141,7 @@ export const EditClientForm: StandardFC<EditClientFormProps> = wrap(function Edi
 					county: contact?.address?.county || emptyStr,
 					state: contact?.address?.state || emptyStr,
 					zip: contact?.address?.zip || emptyStr,
-					notes: contact?.notes ?? '',
+					notes: contact?.notes || emptyStr,
 					race: contact?.demographics?.race || emptyStr,
 					raceCustom: contact?.demographics?.raceOther || emptyStr,
 					gender: contact?.demographics?.gender || emptyStr,

--- a/packages/webapp/src/components/forms/EditClientForm/index.tsx
+++ b/packages/webapp/src/components/forms/EditClientForm/index.tsx
@@ -101,7 +101,8 @@ export const EditClientForm: StandardFC<EditClientFormProps> = wrap(function Edi
 				genderOther: values.gender === lastGenderOption.key ? values.genderCustom : '',
 				ethnicityOther: values.ethnicity === lastEthnicityOption.key ? values.ethnicityCustom : ''
 			},
-			tags: values?.tags ? values.tags.map((a) => a.value) : undefined
+			tags: values?.tags ? values.tags.map((a) => a.value) : undefined,
+			notes: values?.notes
 		}
 
 		const response = await updateContact(editContact)
@@ -140,6 +141,7 @@ export const EditClientForm: StandardFC<EditClientFormProps> = wrap(function Edi
 					county: contact?.address?.county || emptyStr,
 					state: contact?.address?.state || emptyStr,
 					zip: contact?.address?.zip || emptyStr,
+					notes: contact?.notes ?? '',
 					race: contact?.demographics?.race || emptyStr,
 					raceCustom: contact?.demographics?.raceOther || emptyStr,
 					gender: contact?.demographics?.gender || emptyStr,
@@ -312,6 +314,18 @@ export const EditClientForm: StandardFC<EditClientFormProps> = wrap(function Edi
 									/>
 								</Col>
 							</Row>
+
+							<FormSectionTitle>{t('editClient.fields.notes')}</FormSectionTitle>
+							<FormikField
+								as='textarea'
+								autoComplete='off'
+								name='notes'
+								disabled={isArchived}
+								placeholder={t('editClient.fields.notesPlaceholder')}
+								className={styles.field}
+								error={errors.notes}
+								errorClassName={styles.errorLabel}
+							/>
 
 							{/* Demographics */}
 							<Row className='mb-4 pb-2 flex-col flex-md-row'>

--- a/packages/webapp/src/hooks/api/fragments/index.ts
+++ b/packages/webapp/src/hooks/api/fragments/index.ts
@@ -107,6 +107,7 @@ export const ContactFields = gql`
 			preferredLanguageOther
 			preferredContactTime
 		}
+		notes
 	}
 `
 

--- a/packages/webapp/src/locales/en-US/clients.json
+++ b/packages/webapp/src/locales/en-US/clients.json
@@ -78,7 +78,11 @@
       "tags": "Tags",
       "_tags.comment": "Tags field label",
       "addTagsPlaceholder": "Add tags...",
-      "_addTagsPlaceholder.comment": "Placeholder for add tags field"
+      "_addTagsPlaceholder.comment": "Placeholder for add tags field",
+      "notes": "Notes",
+      "_notes.comment": "Notes added to a client information, freeform",
+      "notesPlaceholder": "Add pertinent details or uncategorized information",
+      "_notesPlaceholder.comment": "Placeholder for the notes field"
     },
     "buttons": {
       "createClient": "Create Client",
@@ -133,7 +137,11 @@
       "tags": "Tags",
       "_tags.comment": "Tags field label",
       "addTagsPlaceholder": "Add tags...",
-      "_addTagsPlaceholder.comment": "Placeholder for add tags field"
+      "_addTagsPlaceholder.comment": "Placeholder for add tags field",
+      "notes": "Notes",
+      "_notes.comment": "Notes added to a client information, freeform",
+      "notesPlaceholder": "Add pertinent details or uncategorized information",
+      "_notesPlaceholder.comment": "Placeholder for the notes field"
     },
     "buttons": {
       "save": "Save",

--- a/packages/webapp/src/locales/es-US/clients.json
+++ b/packages/webapp/src/locales/es-US/clients.json
@@ -44,7 +44,9 @@
       "statePlaceHolder": "Estado",
       "zipCodePlaceholder": "Código postal",
       "tags": "Etiquetas adicionales",
-      "addTagsPlaceholder": "Agregar etiquetas..."
+      "addTagsPlaceholder": "Agregar etiquetas...",
+      "notes": "Notas",
+      "notesPlaceholder": ""
     },
     "buttons": {
       "createClient": "Crear cliente"
@@ -77,7 +79,9 @@
       "statePlaceHolder": "Estado",
       "zipCodePlaceholder": "Código postal",
       "tags": "Etiquetas adicionales",
-      "addTagsPlaceholder": "Agregar etiquetas..."
+      "addTagsPlaceholder": "Agregar etiquetas...",
+      "notes": "Notas",
+      "notesPlaceholder": ""
     },
     "buttons": {
       "save": "Guardar",


### PR DESCRIPTION
**What**
- fix #326 

**How**
- Add a new field `notes` to the Schema, DB, DTO, GraphQL resolvers, GraphQL fragments
- Add a new input field called `notes` on the Add/Edit client forms