### PR TITLE
Add Tag applied Telemetry to the Add/Edit Client/Request/Services forms

### DIFF
--- a/packages/webapp/src/components/forms/AddClientForm/index.tsx
+++ b/packages/webapp/src/components/forms/AddClientForm/index.tsx
@@ -119,6 +119,7 @@ export const AddClientForm: StandardFC<AddClientFormProps> = wrap(function AddCl
 					})
 				})
 			}
+
 			closeForm()
 		} else {
 			setSubmitMessage(response.message)

--- a/packages/webapp/src/components/forms/AddClientForm/index.tsx
+++ b/packages/webapp/src/components/forms/AddClientForm/index.tsx
@@ -21,7 +21,7 @@ import { useState } from 'react'
 import { TagSelect } from '~ui/TagSelect'
 import { Namespace, useTranslation } from '~hooks/useTranslation'
 import { useCurrentUser } from '~hooks/api/useCurrentUser'
-import { wrap } from '~utils/appinsights'
+import { wrap, trackEvent } from '~utils/appinsights'
 import { CLIENT_DEMOGRAPHICS } from '~constants'
 import type { IDatePickerStyles } from '@fluentui/react'
 import { DatePicker } from '@fluentui/react'
@@ -106,6 +106,19 @@ export const AddClientForm: StandardFC<AddClientFormProps> = wrap(function AddCl
 
 		if (response.status === StatusType.Success) {
 			setSubmitMessage(null)
+
+			if (newContact?.tags) {
+				newContact.tags.forEach((tag) => {
+					trackEvent({
+						name: 'Tag Applied',
+						properties: {
+							'Organization ID': newContact.orgId,
+							'Tag ID': tag,
+							'Used On': 'client'
+						}
+					})
+				})
+			}
 			closeForm()
 		} else {
 			setSubmitMessage(response.message)

--- a/packages/webapp/src/components/forms/AddRequestForm/index.tsx
+++ b/packages/webapp/src/components/forms/AddRequestForm/index.tsx
@@ -24,9 +24,10 @@ import { get } from 'lodash'
 import { Namespace, useTranslation } from '~hooks/useTranslation'
 import { FormikField } from '~ui/FormikField'
 import styles from './index.module.scss'
-import { wrap } from '~utils/appinsights'
+import { wrap, trackEvent } from '~utils/appinsights'
 import { NewFormPanel } from '~components/ui/NewFormPanel'
 import { useLocale } from '~hooks/useLocale'
+import { useCurrentUser } from '~hooks/api/useCurrentUser'
 
 interface AddRequestFormProps {
 	onSubmit: (form: any) => void
@@ -81,6 +82,7 @@ export const AddRequestForm: StandardFC<AddRequestFormProps> = wrap(function Add
 	showAssignSpecialist = true
 }) {
 	const { t } = useTranslation(Namespace.Requests)
+	const { orgId } = useCurrentUser()
 	const [showAddTag, { setTrue: openAddTag, setFalse: closeAddTag }] = useBoolean(false)
 	const [locale] = useLocale()
 	const actions = [
@@ -127,6 +129,19 @@ export const AddRequestForm: StandardFC<AddRequestFormProps> = wrap(function Add
 						contactIds: values.contactIds?.map((i) => i.value)
 					}
 					onSubmit(_values)
+					if (_values?.tags) {
+						_values.tags.forEach((tag) => {
+							trackEvent({
+								name: 'Tag Applied',
+								properties: {
+									'Organization ID': orgId,
+									'Tag ID': tag,
+									'Used On': 'request'
+								}
+							})
+						})
+					}
+
 					closeAddTag()
 				}}
 			>

--- a/packages/webapp/src/components/forms/AddServiceForm/index.tsx
+++ b/packages/webapp/src/components/forms/AddServiceForm/index.tsx
@@ -21,10 +21,11 @@ import { FormikButton } from '~components/ui/FormikButton'
 import { Modal, Toggle } from '@fluentui/react'
 import { useBoolean } from '@fluentui/react-hooks'
 import { FormGenerator } from '~components/ui/FormGenerator'
-import { wrap } from '~utils/appinsights'
+import { wrap, trackEvent } from '~utils/appinsights'
 import * as yup from 'yup'
 import { noop } from '~utils/noop'
 import { useFormBuilderHelpers } from '~hooks/useFormBuilderHelpers'
+import { useCurrentUser } from '~hooks/api/useCurrentUser'
 
 interface AddServiceFormProps {
 	title?: string
@@ -51,6 +52,7 @@ export const AddServiceForm: StandardFC<AddServiceFormProps> = wrap(function Add
 	])
 	const { isLG } = useWindowSize()
 	const { t } = useTranslation(Namespace.Services)
+	const { orgId } = useCurrentUser()
 	const [isModalOpen, { setTrue: showModal, setFalse: hideModal }] = useBoolean(false)
 	const [selectedService, setSelectedService] = useState<Service | null>(null)
 	const [warningMuted, setWarningMuted] = useState(true)
@@ -80,6 +82,19 @@ export const AddServiceForm: StandardFC<AddServiceFormProps> = wrap(function Add
 				validationSchema={serviceSchema}
 				onSubmit={(values) => {
 					onSubmit(transformValues(values))
+
+					if (values?.tags) {
+						values.tags.forEach((tag) => {
+							trackEvent({
+								name: 'Tag Applied',
+								properties: {
+									'Organization ID': orgId,
+									'Tag ID': tag.value,
+									'Used On': 'service'
+								}
+							})
+						})
+					}
 				}}
 			>
 				{({ errors, values }) => {

--- a/packages/webapp/src/components/forms/EditClientForm/index.tsx
+++ b/packages/webapp/src/components/forms/EditClientForm/index.tsx
@@ -22,7 +22,7 @@ import { useState } from 'react'
 import { TagSelect } from '~ui/TagSelect'
 import { Namespace, useTranslation } from '~hooks/useTranslation'
 import { useCurrentUser } from '~hooks/api/useCurrentUser'
-import { wrap } from '~utils/appinsights'
+import { wrap, trackEvent } from '~utils/appinsights'
 import { FormikRadioGroup } from '~ui/FormikRadioGroup'
 import { ArchiveClientModal } from '~ui/ArchiveClientModal'
 import { CLIENT_DEMOGRAPHICS } from '~constants'
@@ -111,6 +111,20 @@ export const EditClientForm: StandardFC<EditClientFormProps> = wrap(function Edi
 
 		if (response.status === StatusType.Success) {
 			setSubmitMessage(null)
+
+			if (editContact?.tags) {
+				editContact.tags.forEach((tag) => {
+					trackEvent({
+						name: 'Tag Applied',
+						properties: {
+							'Organization ID': editContact.orgId,
+							'Tag ID': tag,
+							'Used On': 'client'
+						}
+					})
+				})
+			}
+
 			closeForm()
 		} else {
 			setSubmitMessage(response.message)

--- a/packages/webapp/src/components/forms/EditRequestForm/index.tsx
+++ b/packages/webapp/src/components/forms/EditRequestForm/index.tsx
@@ -24,7 +24,8 @@ import { SpecialistSelect } from '~components/ui/SpecialistSelect'
 import { TagSelect } from '~components/ui/TagSelect'
 
 import { Namespace, useTranslation } from '~hooks/useTranslation'
-import { wrap } from '~utils/appinsights'
+import { useCurrentUser } from '~hooks/api/useCurrentUser'
+import { wrap, trackEvent } from '~utils/appinsights'
 import { noop } from '~utils/noop'
 
 interface EditRequestFormProps {
@@ -40,6 +41,8 @@ export const EditRequestForm: StandardFC<EditRequestFormProps> = wrap(function E
 	onSubmit = noop
 }) {
 	const { t } = useTranslation(Namespace.Requests)
+	const { orgId } = useCurrentUser()
+
 	const formTitle = title || t('editRequestTitle')
 
 	const EditRequestSchema = yup.object().shape({
@@ -73,6 +76,18 @@ export const EditRequestForm: StandardFC<EditRequestFormProps> = wrap(function E
 			userId: values.userId?.value,
 			contactIds: values.contactIds?.map((i) => i.value)
 		})
+		if (values?.tags) {
+			values.tags.forEach((tag) => {
+				trackEvent({
+					name: 'Tag Applied',
+					properties: {
+						'Organization ID': orgId,
+						'Tag ID': tag.value,
+						'Used On': 'request'
+					}
+				})
+			})
+		}
 	}
 
 	const initialValues = {

--- a/packages/webapp/src/components/forms/EditServiceForm/index.tsx
+++ b/packages/webapp/src/components/forms/EditServiceForm/index.tsx
@@ -23,10 +23,11 @@ import { FormikButton } from '~components/ui/FormikButton'
 import { Modal, Toggle } from '@fluentui/react'
 import { useBoolean } from '@fluentui/react-hooks'
 import { FormGenerator } from '~components/ui/FormGenerator'
-import { wrap } from '~utils/appinsights'
+import { wrap, trackEvent } from '~utils/appinsights'
 import * as yup from 'yup'
 import { empty, noop } from '~utils/noop'
 import { useFormBuilderHelpers } from '~hooks/useFormBuilderHelpers'
+import { useCurrentUser } from '~hooks/api/useCurrentUser'
 
 interface EditServiceFormProps {
 	title?: string
@@ -40,6 +41,7 @@ export const EditServiceForm: StandardFC<EditServiceFormProps> = wrap(function E
 }) {
 	const { isLG } = useWindowSize()
 	const { t } = useTranslation(Namespace.Services)
+	const { orgId } = useCurrentUser()
 	const [isModalOpen, { setTrue: showModal, setFalse: hideModal }] = useBoolean(false)
 	const [selectedService, setSelectedService] = useState<Service | null>(null)
 	const [warningMuted, setWarningMuted] = useState(true)
@@ -106,6 +108,19 @@ export const EditServiceForm: StandardFC<EditServiceFormProps> = wrap(function E
 				validationSchema={serviceSchema}
 				onSubmit={(values) => {
 					onSubmit(transformValues(values))
+
+					if (values?.tags) {
+						values.tags.forEach((tag) => {
+							trackEvent({
+								name: 'Tag Applied',
+								properties: {
+									'Organization ID': orgId,
+									'Tag ID': tag.value,
+									'Used On': 'service'
+								}
+							})
+						})
+					}
 				}}
 			>
 				{({ errors, values }) => {


### PR DESCRIPTION
fix #355 

Send telementry in the following format, on event is sent per Tag ID applied.
```
Event Name: 'Tag Applied'
Organization ID: orgID
Tag: ID: tag ID
Used on: 'client' | 'request' | 'service'
```

for example:
<img width="495" alt="Screen Shot 2022-03-08 at 16 35 32" src="https://user-images.githubusercontent.com/636801/157329194-c19da098-d9f9-43b1-8587-6893f1837858.png">
