### PR TITLE
Remove overlap of text tables

### DIFF
--- a/packages/webapp/src/components/lists/InactiveRequestList/columns.tsx
+++ b/packages/webapp/src/components/lists/InactiveRequestList/columns.tsx
@@ -18,6 +18,7 @@ export function usePageColumns(): IPaginatedListColumn[] {
 			{
 				key: 'title',
 				name: t('requestListColumns.title'),
+				className: 'col-3',
 				onRenderColumnItem(engagement: Engagement) {
 					return <EngagementTitleColumnItem engagement={engagement} />
 				}
@@ -25,7 +26,7 @@ export function usePageColumns(): IPaginatedListColumn[] {
 			{
 				key: 'clients',
 				name: t('requestListColumns.clients'),
-				className: 'col-4',
+				className: 'col-3',
 				onRenderColumnItem(engagement: Engagement) {
 					return <EngagementClientsColumnItem engagement={engagement} />
 				}

--- a/packages/webapp/src/components/lists/MyRequestsList/columns.tsx
+++ b/packages/webapp/src/components/lists/MyRequestsList/columns.tsx
@@ -20,6 +20,7 @@ export function usePageColumns(actions: Array<IMultiActionButtons<Engagement>>) 
 			{
 				key: 'title',
 				name: t('requestListColumns.title'),
+				className: 'col-3',
 				onRenderColumnItem(engagement: Engagement) {
 					return <EngagementTitleColumnItem engagement={engagement} />
 				}
@@ -27,7 +28,7 @@ export function usePageColumns(actions: Array<IMultiActionButtons<Engagement>>) 
 			{
 				key: 'clients',
 				name: t('requestListColumns.clients'),
-				className: 'col-4',
+				className: 'col-3',
 				onRenderColumnItem(engagement: Engagement) {
 					return <EngagementClientsColumnItem engagement={engagement} />
 				}

--- a/packages/webapp/src/components/lists/RequestList/columns.tsx
+++ b/packages/webapp/src/components/lists/RequestList/columns.tsx
@@ -26,6 +26,7 @@ export function usePageColumns(
 			{
 				key: 'title',
 				name: t('requestListColumns.title'),
+				className: 'col-3',
 				onRenderColumnItem(engagement: Engagement) {
 					return <EngagementTitleColumnItem engagement={engagement} />
 				}
@@ -33,7 +34,7 @@ export function usePageColumns(
 			{
 				key: 'clients',
 				name: t('requestListColumns.clients'),
-				className: 'col-4',
+				className: 'col-3',
 				onRenderColumnItem(engagement: Engagement) {
 					return <EngagementClientsColumnItem engagement={engagement} />
 				}

--- a/packages/webapp/src/components/ui/EngagementTitleColumnItem/index.tsx
+++ b/packages/webapp/src/components/ui/EngagementTitleColumnItem/index.tsx
@@ -8,10 +8,12 @@ import type { FC } from 'react'
 import { memo } from 'react'
 import { CardRowTitle } from '~components/ui/CardRowTitle'
 import { useNavCallback } from '~hooks/useNavCallback'
+import { truncate } from 'lodash'
 
 export const EngagementTitleColumnItem: FC<{ engagement: Engagement }> = memo(
 	function EngagementTitleColumnItem({ engagement }) {
 		const handleClick = useNavCallback(null, { engagement: engagement.id })
-		return <CardRowTitle tag='span' title={engagement.title} titleLink='/' onClick={handleClick} />
+		const title = truncate(engagement.title, { length: 40 })
+		return <CardRowTitle tag='span' title={title} titleLink='/' onClick={handleClick} />
 	}
 )

--- a/packages/webapp/src/components/ui/PaginatedList/index.module.scss
+++ b/packages/webapp/src/components/ui/PaginatedList/index.module.scss
@@ -18,6 +18,7 @@
 
 .columnItem {
 	padding: 12px 14px;
+	overflow-wrap: anywhere;
 }
 
 // Doing underscores instead of multi-class because of SCSS modules


### PR DESCRIPTION
**What**
- fix #311 

**How**
- Add `overflow-wrap: anywhere;` to allow for word break event without spaces.
- Make sure this worked on all tables on the app.
- Shorten the length of a _Request_ title.
- Improve the dashboard by giving more room to the title column.
