### PR TITLE
Feature/replace tag pulldown select filter with table column filter

### DIFF
--- a/packages/webapp/src/components/lists/ReportList/reports/ClientReport/useClientReportColumns.tsx
+++ b/packages/webapp/src/components/lists/ReportList/reports/ClientReport/useClientReportColumns.tsx
@@ -3,7 +3,7 @@
  * Licensed under the MIT license. See LICENSE file in the project.
  */
 import type { Contact } from '@cbosuite/schema/dist/client-types'
-import type { IDropdownOption } from '@fluentui/react'
+import type { CustomOption } from '~components/ui/CustomOptionsFilter'
 import { useMemo } from 'react'
 import { CustomDateRangeFilter } from '~components/ui/CustomDateRangeFilter'
 import { CustomOptionsFilter } from '~components/ui/CustomOptionsFilter'
@@ -21,7 +21,7 @@ import { getContactTitle } from '~components/lists/ContactList/ContactTitle'
 import { sortByAlphanumeric, sortByDate, sortByTags } from '~utils/sorting'
 
 export function useClientReportColumns(
-	filterColumns: (columnId: string, option: IDropdownOption) => void,
+	filterColumns: (columnId: string, option: CustomOption) => void,
 	filterColumnTextValue: (key: string, value: string) => void,
 	filterRangedValues: (key: string, value: string[]) => void,
 	getDemographicValue: (demographicKey: string, contact: Contact) => string,

--- a/packages/webapp/src/components/lists/ReportList/reports/RequestReport/useRequestReportColumns/useContactFormColumns.tsx
+++ b/packages/webapp/src/components/lists/ReportList/reports/RequestReport/useRequestReportColumns/useContactFormColumns.tsx
@@ -9,7 +9,7 @@ import { CustomTextFieldFilter } from '~components/ui/CustomTextFieldFilter'
 import { CLIENT_DEMOGRAPHICS } from '~constants'
 import { Namespace, useTranslation } from '~hooks/useTranslation'
 import styles from '../../../index.module.scss'
-import type { IDropdownOption } from '@fluentui/react'
+import type { CustomOption } from '~components/ui/CustomOptionsFilter'
 import { CustomDateRangeFilter } from '~components/ui/CustomDateRangeFilter'
 import { TagBadgeList } from '~ui/TagBadgeList'
 import { useLocale } from '~hooks/useLocale'
@@ -19,7 +19,7 @@ import { useGetValue } from '~components/lists/ReportList/hooks'
 import { sortByAlphanumeric, sortByDate, sortByTags } from '~utils/sorting'
 
 export function useContactFormColumns(
-	filterColumns: (columnId: string, option: IDropdownOption) => void,
+	filterColumns: (columnId: string, option: CustomOption) => void,
 	filterColumnTextValue: (key: string, value: string) => void,
 	filterRangedValues: (key: string, value: string[]) => void,
 	getDemographicValue: (demographicKey: string, contact: Contact) => string,

--- a/packages/webapp/src/components/lists/ReportList/reports/RequestReport/useRequestReportColumns/useRequestFieldColumns.tsx
+++ b/packages/webapp/src/components/lists/ReportList/reports/RequestReport/useRequestReportColumns/useRequestFieldColumns.tsx
@@ -8,7 +8,7 @@ import { CustomTextFieldFilter } from '~components/ui/CustomTextFieldFilter'
 import type { IPaginatedTableColumn } from '~components/ui/PaginatedTable/types'
 import styles from '../../../index.module.scss'
 import { CustomDateRangeFilter } from '~components/ui/CustomDateRangeFilter'
-import type { IDropdownOption } from '@fluentui/react'
+import type { CustomOption } from '~components/ui/CustomOptionsFilter'
 import { useLocale } from '~hooks/useLocale'
 import { Namespace, useTranslation } from '~hooks/useTranslation'
 import { CustomOptionsFilter } from '~components/ui/CustomOptionsFilter'
@@ -21,7 +21,7 @@ import { sortByAlphanumeric, sortByDate, sortByTags } from '~utils/sorting'
 import { truncate } from 'lodash'
 
 export function useRequestFieldColumns(
-	filterColumns: (columnId: string, option: IDropdownOption) => void,
+	filterColumns: (columnId: string, option: CustomOption) => void,
 	filterColumnTextValue: (key: string, value: string) => void,
 	filterRangedValues: (key: string, value: string[]) => void,
 	hiddenFields: Record<string, boolean>,

--- a/packages/webapp/src/components/lists/ReportList/reports/ServiceReport/useServiceReportColumns/useServiceFieldColumns.tsx
+++ b/packages/webapp/src/components/lists/ReportList/reports/ServiceReport/useServiceReportColumns/useServiceFieldColumns.tsx
@@ -10,7 +10,7 @@ import { CustomTextFieldFilter } from '~components/ui/CustomTextFieldFilter'
 import type { IPaginatedTableColumn } from '~components/ui/PaginatedTable/types'
 import styles from '../../../index.module.scss'
 import { CustomDateRangeFilter } from '~components/ui/CustomDateRangeFilter'
-import type { IDropdownOption } from '@fluentui/react'
+import type { CustomOption } from '~components/ui/CustomOptionsFilter'
 import { CustomNumberRangeFilter } from '~components/ui/CustomNumberRangeFilter'
 import { ShortString } from '~components/ui/ShortString'
 import { useLocale } from '~hooks/useLocale'
@@ -32,7 +32,7 @@ function shorten(value: string): string {
 export function useServiceFieldColumns(
 	data: unknown[],
 	fields: ServiceField[],
-	filterColumns: (columnId: string, option: IDropdownOption) => void,
+	filterColumns: (columnId: string, option: CustomOption) => void,
 	filterColumnTextValue: (key: string, value: string) => void,
 	filterRangedValues: (key: string, value: string[]) => void,
 	hiddenFields: Record<string, boolean>,

--- a/packages/webapp/src/components/lists/TagsList/columns.tsx
+++ b/packages/webapp/src/components/lists/TagsList/columns.tsx
@@ -18,7 +18,8 @@ import { TAG_CATEGORIES } from '~constants'
 
 export function usePageColumns(
 	actions: IMultiActionButtons<Tag>[],
-	filterListByCategory?: (filterOption: CustomOption) => void
+	filterListByCategory?: (filterOption: CustomOption) => void,
+	clearFilterByCategory?: () => void
 ): IPaginatedListColumn[] {
 	const { t, c } = useTranslation(Namespace.Tags)
 	return useMemo(
@@ -60,6 +61,7 @@ export function usePageColumns(
 								}
 							})}
 							onFilterChanged={(option) => filterListByCategory(option)}
+							onClearFilter={clearFilterByCategory}
 						/>
 					)
 				}

--- a/packages/webapp/src/components/lists/TagsList/columns.tsx
+++ b/packages/webapp/src/components/lists/TagsList/columns.tsx
@@ -54,7 +54,7 @@ export function usePageColumns(
 							placeholder={name}
 							options={TAG_CATEGORIES.map((category, index) => {
 								return {
-									key: index,
+									key: category,
 									text: c(`tagCategory.${category}`)
 								}
 							})}

--- a/packages/webapp/src/components/lists/TagsList/columns.tsx
+++ b/packages/webapp/src/components/lists/TagsList/columns.tsx
@@ -104,7 +104,7 @@ export function usePageColumns(
 				}
 			}
 		],
-		[actions, t, c, filterListByCategory]
+		[actions, t, c, filterListByCategory, clearFilterByCategory]
 	)
 }
 

--- a/packages/webapp/src/components/lists/TagsList/columns.tsx
+++ b/packages/webapp/src/components/lists/TagsList/columns.tsx
@@ -13,11 +13,12 @@ import { ShortString } from '~ui/ShortString'
 import { Namespace, useTranslation } from '~hooks/useTranslation'
 import { MobileCard } from './MobileCard'
 import { CustomOptionsFilter } from '~components/ui/CustomOptionsFilter'
+import type { CustomOption } from '~components/ui/CustomOptionsFilter'
 import { TAG_CATEGORIES } from '~constants'
 
 export function usePageColumns(
 	actions: IMultiActionButtons<Tag>[],
-	filterListByCategory?: (filterOption: OptionType) => void
+	filterListByCategory?: (filterOption: CustomOption) => void
 ): IPaginatedListColumn[] {
 	const { t, c } = useTranslation(Namespace.Tags)
 	return useMemo(

--- a/packages/webapp/src/components/lists/TagsList/columns.tsx
+++ b/packages/webapp/src/components/lists/TagsList/columns.tsx
@@ -11,11 +11,14 @@ import type { IMultiActionButtons } from '~ui/MultiActionButton2'
 import { MultiActionButton } from '~ui/MultiActionButton2'
 import { ShortString } from '~ui/ShortString'
 import { Namespace, useTranslation } from '~hooks/useTranslation'
-import { useWindowSize } from '~hooks/useWindowSize'
 import { MobileCard } from './MobileCard'
+import { CustomOptionsFilter } from '~components/ui/CustomOptionsFilter'
+import { TAG_CATEGORIES } from '~constants'
 
-export function usePageColumns(actions: IMultiActionButtons<Tag>[]): IPaginatedListColumn[] {
-	const { isMD } = useWindowSize()
+export function usePageColumns(
+	actions: IMultiActionButtons<Tag>[],
+	filterListByCategory?: (filterOption: OptionType) => void
+): IPaginatedListColumn[] {
 	const { t, c } = useTranslation(Namespace.Tags)
 	return useMemo(
 		() => [
@@ -33,18 +36,31 @@ export function usePageColumns(actions: IMultiActionButtons<Tag>[]): IPaginatedL
 			{
 				key: 'description',
 				name: t('requestTagListColumns.description'),
-				className: 'col-md-4',
+				className: 'col-md-2',
 				onRenderColumnItem(tag: Tag) {
-					return <ShortString text={tag.description} limit={isMD ? 64 : 24} />
+					return <ShortString text={tag.description} limit={64} />
 				}
 			},
 			{
 				key: 'category',
 				name: t('requestTagListColumns.category'),
-				className: 'col-md-1',
 				onRenderColumnItem(tag: Tag) {
 					const group = tag?.category ?? TagCategory.Other
 					return <>{c(`tagCategory.${group}`)}</>
+				},
+				onRenderColumnHeader(key, name) {
+					return (
+						<CustomOptionsFilter
+							placeholder={name}
+							options={TAG_CATEGORIES.map((category, index) => {
+								return {
+									key: index,
+									text: c(`tagCategory.${category}`)
+								}
+							})}
+							onFilterChanged={(option) => filterListByCategory(option)}
+						/>
+					)
 				}
 			},
 			{
@@ -85,7 +101,7 @@ export function usePageColumns(actions: IMultiActionButtons<Tag>[]): IPaginatedL
 				}
 			}
 		],
-		[actions, t, c, isMD]
+		[actions, t, c, filterListByCategory]
 	)
 }
 

--- a/packages/webapp/src/components/lists/TagsList/index.tsx
+++ b/packages/webapp/src/components/lists/TagsList/index.tsx
@@ -41,56 +41,34 @@ export const TagsList: StandardFC<TagsListProps> = wrap(function TagsList({ titl
 	const [isEditFormOpen, { setTrue: openEditTagPanel, setFalse: dismissEditTagPanel }] =
 		useBoolean(false)
 	const [selectedTag, setSelectedTag] = useState<Tag>(null)
-	const [selectedCategories, setSelectedCategories] = useState<OptionType[]>([])
+	const [selectedCategories, setSelectedCategories] = useState(new Set<string>())
 
 	useEffect(() => {
 		setFilteredList(org?.tags || [])
 	}, [org?.tags])
 
-	// ----- Filtered tag list
-
-	const tagsList =
-		!selectedCategories.length > 0
-			? org?.tags
-			: org?.tags.filter((tag: Tag) => selectedCategories.includes(tag.category))
-
 	const filterList = (filterOption: OptionType) => {
-		// console.log('filterOption', filterOption)
-
+		// Keep track of the user selection
 		const setCategories = new Set(selectedCategories)
 		if (filterOption.selected) {
-			setCategories.add(filterOption.text)
+			setCategories.add(filterOption.key)
 		} else {
-			setCategories.delete(filterOption.text)
+			setCategories.delete(filterOption.key)
 		}
 		setSelectedCategories(setCategories)
 
-		/* 
-		logger('filterOption', filterOption)
-		if (!filterOption?.value) {
-			logger('filterOption', filterOption)
-		}
-		const value = filterOption?.value
-		let filteredTags: Tag[]
+		// Filter the tag list
+		const tags: Tag[] = org?.tags ?? []
 
-		if (!value || value === 'ALL' || value === '') {
-			// Show all org tags
-			filteredTags = org?.tags
-		} else if (value === TagCategory.Other) {
-			// Show tags without category or other
-			filteredTags = org?.tags.filter((tag: Tag) => !tag.category || tag.category === value)
+		if (setCategories.size > 0) {
+			const filteredTags = tags.filter((tag: Tag) => setCategories.has(tag.category))
+			setFilteredList(filteredTags)
 		} else {
-			// Filter on selected category
-			filteredTags = org?.tags.filter((tag: Tag) => tag.category === value)
+			setFilteredList(tags)
 		}
-
-		setFilteredList(filteredTags || []) 
-		*/
 	}
 
 	const searchList = useTagSearchHandler(org?.tags || [], setFilteredList)
-
-	// ----
 
 	const onTagClick = useCallback(
 		(tag: Tag) => {
@@ -119,7 +97,7 @@ export const TagsList: StandardFC<TagsListProps> = wrap(function TagsList({ titl
 			{isMD ? (
 				<PaginatedList
 					title={title}
-					list={tagsList}
+					list={filteredList}
 					itemsPerPage={20}
 					columns={pageColumns}
 					rowClassName='align-items-center'

--- a/packages/webapp/src/components/lists/TagsList/index.tsx
+++ b/packages/webapp/src/components/lists/TagsList/index.tsx
@@ -8,7 +8,6 @@ import cx from 'classnames'
 import { useRecoilValue } from 'recoil'
 import { organizationState } from '~store'
 import type { Tag } from '@cbosuite/schema/dist/client-types'
-// import { TagCategory } from '@cbosuite/schema/dist/client-types'
 import { useCallback, useEffect, useState } from 'react'
 import { PaginatedList } from '~ui/PaginatedList'
 import type { IMultiActionButtons } from '~ui/MultiActionButton2'
@@ -18,13 +17,10 @@ import { AddTagForm } from '~forms/AddTagForm'
 import { useWindowSize } from '~hooks/useWindowSize'
 import { EditTagForm } from '~forms/EditTagForm'
 import { Namespace, useTranslation } from '~hooks/useTranslation'
-// import { TAG_CATEGORIES } from '~constants'
 import type { OptionType } from '~ui/ReactSelect'
 import { wrap } from '~utils/appinsights'
-import { createLogger } from '~utils/createLogger'
 import { useTagSearchHandler } from '~hooks/useTagSearchHandler'
 import { useMobileColumns, usePageColumns } from './columns'
-// const logger = createLogger('tagsList')
 
 interface TagsListProps {
 	title?: string

--- a/packages/webapp/src/components/lists/TagsList/index.tsx
+++ b/packages/webapp/src/components/lists/TagsList/index.tsx
@@ -17,7 +17,7 @@ import { AddTagForm } from '~forms/AddTagForm'
 import { useWindowSize } from '~hooks/useWindowSize'
 import { EditTagForm } from '~forms/EditTagForm'
 import { Namespace, useTranslation } from '~hooks/useTranslation'
-import type { OptionType } from '~ui/ReactSelect'
+import type { CustomOption } from '~components/ui/CustomOptionsFilter'
 import { wrap } from '~utils/appinsights'
 import { useTagSearchHandler } from '~hooks/useTagSearchHandler'
 import { useMobileColumns, usePageColumns } from './columns'
@@ -43,7 +43,7 @@ export const TagsList: StandardFC<TagsListProps> = wrap(function TagsList({ titl
 		setFilteredList(org?.tags || [])
 	}, [org?.tags])
 
-	const filterList = (filterOption: OptionType) => {
+	const filterList = (filterOption: CustomOption) => {
 		// Keep track of the user selection
 		const setCategories = new Set(selectedCategories)
 		if (filterOption.selected) {

--- a/packages/webapp/src/components/lists/TagsList/index.tsx
+++ b/packages/webapp/src/components/lists/TagsList/index.tsx
@@ -43,7 +43,7 @@ export const TagsList: StandardFC<TagsListProps> = wrap(function TagsList({ titl
 		setFilteredList(org?.tags || [])
 	}, [org?.tags])
 
-	const filterList = (filterOption: CustomOption) => {
+	const filterList = function (filterOption: CustomOption) {
 		// Keep track of the user selection
 		const setCategories = new Set(selectedCategories)
 		if (filterOption.selected) {
@@ -64,7 +64,7 @@ export const TagsList: StandardFC<TagsListProps> = wrap(function TagsList({ titl
 		}
 	}
 
-	const clearFilter = () => {
+	const clearFilter = function () {
 		setSelectedCategories(new Set())
 		setFilteredList(org?.tags ?? [])
 	}

--- a/packages/webapp/src/components/lists/TagsList/index.tsx
+++ b/packages/webapp/src/components/lists/TagsList/index.tsx
@@ -64,6 +64,11 @@ export const TagsList: StandardFC<TagsListProps> = wrap(function TagsList({ titl
 		}
 	}
 
+	const clearFilter = () => {
+		setSelectedCategories(new Set())
+		setFilteredList(org?.tags ?? [])
+	}
+
 	const searchList = useTagSearchHandler(org?.tags || [], setFilteredList)
 
 	const onTagClick = useCallback(
@@ -85,7 +90,7 @@ export const TagsList: StandardFC<TagsListProps> = wrap(function TagsList({ titl
 		}
 	]
 
-	const pageColumns = usePageColumns(actions, filterList)
+	const pageColumns = usePageColumns(actions, filterList, clearFilter)
 	const mobileColumns = useMobileColumns(actions, onTagClick)
 
 	return (

--- a/packages/webapp/src/components/ui/CustomOptionsFilter/index.module.scss
+++ b/packages/webapp/src/components/ui/CustomOptionsFilter/index.module.scss
@@ -43,3 +43,12 @@
 		padding: 8px;
 	}
 }
+
+.clearFilter {
+	align-self: end;
+	font-size: 12px;
+
+	i {
+		font-size: inherit;
+	}
+}

--- a/packages/webapp/src/components/ui/CustomOptionsFilter/index.tsx
+++ b/packages/webapp/src/components/ui/CustomOptionsFilter/index.tsx
@@ -15,7 +15,7 @@ import { truncate } from 'lodash'
 import cx from 'classnames'
 
 interface CustomOptionsFilterProps {
-	filterLabel: string
+	filterLabel?: string
 	options: IDropdownOption[]
 	placeholder?: string
 	defaultSelectedKeys?: string[]

--- a/packages/webapp/src/components/ui/CustomOptionsFilter/index.tsx
+++ b/packages/webapp/src/components/ui/CustomOptionsFilter/index.tsx
@@ -71,7 +71,7 @@ export const CustomOptionsFilter: StandardFC<CustomOptionsFilterProps> = wrap(
 			onFilterChanged({ selected: isChecked, ...option })
 		}
 
-		const handleClearAll = function (event?: React.FormEvent<HTMLElement | HTMLInputElement>) {
+		const handleClearAll = function () {
 			setSelected([])
 			onClearFilter()
 		}

--- a/packages/webapp/src/components/ui/CustomOptionsFilter/index.tsx
+++ b/packages/webapp/src/components/ui/CustomOptionsFilter/index.tsx
@@ -4,7 +4,6 @@
  */
 import type { StandardFC } from '~types/StandardFC'
 import { useEffect, useState } from 'react'
-import type { IDropdownOption } from '@fluentui/react'
 import { Callout, Checkbox, Icon } from '@fluentui/react'
 import { useBoolean, useId } from '@fluentui/react-hooks'
 import { wrap } from '~utils/appinsights'
@@ -14,12 +13,18 @@ import styles from './index.module.scss'
 import { truncate } from 'lodash'
 import cx from 'classnames'
 
+export type CustomOption = {
+	key: string
+	text: string
+	selected?: boolean
+}
+
 interface CustomOptionsFilterProps {
 	filterLabel?: string
-	options: IDropdownOption[]
+	options: CustomOption[]
 	placeholder?: string
 	defaultSelectedKeys?: string[]
-	onFilterChanged?: (option: IDropdownOption) => void
+	onFilterChanged?: (option: CustomOption) => void
 	onTrackEvent?: (name: string) => void
 }
 

--- a/packages/webapp/src/components/ui/CustomOptionsFilter/index.tsx
+++ b/packages/webapp/src/components/ui/CustomOptionsFilter/index.tsx
@@ -4,7 +4,7 @@
  */
 import type { StandardFC } from '~types/StandardFC'
 import { useEffect, useState } from 'react'
-import { Callout, Checkbox, Icon } from '@fluentui/react'
+import { ActionButton, Callout, Checkbox, Icon } from '@fluentui/react'
 import { useBoolean, useId } from '@fluentui/react-hooks'
 import { wrap } from '~utils/appinsights'
 import { noop } from '~utils/noop'
@@ -12,6 +12,7 @@ import { SortingClassName } from '~utils/sorting'
 import styles from './index.module.scss'
 import { truncate } from 'lodash'
 import cx from 'classnames'
+import { Namespace, useTranslation } from '~hooks/useTranslation'
 
 export type CustomOption = {
 	key: string
@@ -25,6 +26,7 @@ interface CustomOptionsFilterProps {
 	placeholder?: string
 	defaultSelectedKeys?: string[]
 	onFilterChanged?: (option: CustomOption) => void
+	onClearFilter?: () => void
 	onTrackEvent?: (name: string) => void
 }
 
@@ -35,8 +37,10 @@ export const CustomOptionsFilter: StandardFC<CustomOptionsFilterProps> = wrap(
 		options,
 		defaultSelectedKeys,
 		onFilterChanged = noop,
+		onClearFilter = noop,
 		onTrackEvent = noop
 	}) {
+		const { t } = useTranslation(Namespace.Reporting)
 		const buttonId = useId('filter-callout-button')
 		const [showCallout, { toggle: toggleShowCallout }] = useBoolean(false)
 		const [selected, setSelected] = useState([])
@@ -67,12 +71,17 @@ export const CustomOptionsFilter: StandardFC<CustomOptionsFilterProps> = wrap(
 			onFilterChanged({ selected: isChecked, ...option })
 		}
 
+		const handleClearAll = function (event?: React.FormEvent<HTMLElement | HTMLInputElement>) {
+			setSelected([])
+			onClearFilter()
+		}
+
 		const title = truncate(placeholder)
 		const iconClassname = selected.length > 0 ? styles.iconActive : styles.icon
 		const checkboxes = options?.map((option) => {
 			return (
 				<Checkbox
-					defaultChecked={selected.includes(option.key)}
+					checked={selected.includes(option.key)}
 					key={option.key}
 					label={option.text}
 					name={option.key.toString()}
@@ -96,6 +105,13 @@ export const CustomOptionsFilter: StandardFC<CustomOptionsFilterProps> = wrap(
 						target={`#${buttonId}`}
 					>
 						{checkboxes}
+						<ActionButton
+							className={styles.clearFilter}
+							iconProps={{ iconName: 'Clear' }}
+							onClick={handleClearAll}
+						>
+							{t('customFilters.clearFilter')}
+						</ActionButton>
 					</Callout>
 				)}
 			</header>

--- a/packages/webapp/src/components/ui/PaginatedList/ColumnHeaderRow.tsx
+++ b/packages/webapp/src/components/ui/PaginatedList/ColumnHeaderRow.tsx
@@ -41,11 +41,9 @@ export const ColumnHeaderRow: StandardFC<{
 					}
 
 					return (
-						onRenderColumnHeader(key, name, idx) || (
-							<Col key={idx} className={classList} onClick={handleOnClick}>
-								{name}
-							</Col>
-						)
+						<Col key={idx} className={classList} onClick={handleOnClick}>
+							{onRenderColumnHeader(key, name, idx) || name}
+						</Col>
 					)
 				}
 			)}

--- a/packages/webapp/src/constants/TAG_CATEGORIES.ts
+++ b/packages/webapp/src/constants/TAG_CATEGORIES.ts
@@ -9,5 +9,4 @@ export const TAG_CATEGORIES: TagCategory[] = [
 	TagCategory.Program,
 	TagCategory.Grant,
 	TagCategory.Other
-	// TagCategory.All
 ]


### PR DESCRIPTION
Fix #294 

- Added a filter button on the `Category` header column
- Change the `CustomOptionsFilter` component to be more straightforward
- General tidying up