### PR TITLE
Fix Add/Edit Request forms

### DIFF
--- a/packages/webapp/src/components/forms/AddRequestForm/index.tsx
+++ b/packages/webapp/src/components/forms/AddRequestForm/index.tsx
@@ -20,7 +20,6 @@ import { ActionInput } from '~ui/ActionInput'
 import { TagSelect } from '~ui/TagSelect'
 import { get } from 'lodash'
 import { Namespace, useTranslation } from '~hooks/useTranslation'
-import { FormikField } from '~ui/FormikField'
 import styles from './index.module.scss'
 import { wrap, trackEvent } from '~utils/appinsights'
 import { NewFormPanel } from '~components/ui/NewFormPanel'
@@ -161,12 +160,10 @@ export const AddRequestForm: StandardFC<AddRequestFormProps> = wrap(function Add
 									<Col className='mb-3 mb-md-0'>
 										<FormSectionTitle>{t('addRequestFields.requestTitle')}</FormSectionTitle>
 
-										<FormikField
+										<ActionInput
 											name='title'
-											placeholder={t('addRequestFields.requestTitlePlaceholder')}
-											className={cx(styles.field, 'requestTitleInput')}
-											error={errors.title}
-											errorClassName={cx(styles.errorLabel)}
+											error={get(touched, 'title') ? get(errors, 'title') : undefined}
+											rows='1'
 										/>
 									</Col>
 								</Row>

--- a/packages/webapp/src/components/forms/AddRequestForm/index.tsx
+++ b/packages/webapp/src/components/forms/AddRequestForm/index.tsx
@@ -86,13 +86,8 @@ export const AddRequestForm: StandardFC<AddRequestFormProps> = wrap(function Add
 	const [locale] = useLocale()
 
 	const AddRequestSchema = yup.object().shape({
-		title: yup
-			.string()
-			.min(2, t('addRequestYup.tooShort'))
-			.max(200, t('addRequestYup.tooLong'))
-			.required(t('addRequestYup.required')),
-		contactIds: yup.array().min(1, t('addRequestYup.required')),
-		description: yup.string().required(t('addRequestYup.required'))
+		title: yup.string().min(2, t('addRequestYup.tooShort')).required(t('addRequestYup.required')),
+		contactIds: yup.array().min(1, t('addRequestYup.required'))
 	})
 
 	const [openNewClientFormPanel, setOpenNewClientFormPanel] = useState(false)
@@ -200,10 +195,7 @@ export const AddRequestForm: StandardFC<AddRequestFormProps> = wrap(function Add
 								<Row className='flex-column flex-md-row mb-4'>
 									<Col>
 										<FormSectionTitle>
-											<>
-												{t('addRequestFields.addEndDate')}{' '}
-												<span className='text-normal'>({t('addRequestFields.optional')})</span>
-											</>
+											{t('addRequestFields.addEndDate')} ({t('addRequestFields.optional')})
 										</FormSectionTitle>
 
 										<DatePicker
@@ -226,10 +218,7 @@ export const AddRequestForm: StandardFC<AddRequestFormProps> = wrap(function Add
 								{showAssignSpecialist && (
 									<>
 										<FormSectionTitle>
-											<>
-												{t('addRequestFields.assignSpecialist')}{' '}
-												<span className='text-normal'>({t('addRequestFields.optional')})</span>
-											</>
+											{t('addRequestFields.assignSpecialist')} ({t('addRequestFields.optional')})
 										</FormSectionTitle>
 
 										<Row className='mb-4 pb-2'>
@@ -246,7 +235,9 @@ export const AddRequestForm: StandardFC<AddRequestFormProps> = wrap(function Add
 
 								<Row className='mb-4 pb-2'>
 									<Col>
-										<FormSectionTitle>{t('addRequestFields.description')}</FormSectionTitle>
+										<FormSectionTitle>
+											{t('addRequestFields.description')} ({t('addRequestFields.optional')})
+										</FormSectionTitle>
 
 										<ActionInput
 											name='description'
@@ -265,26 +256,10 @@ export const AddRequestForm: StandardFC<AddRequestFormProps> = wrap(function Add
 
 								<FormikSubmitButton
 									className='btnAddRequestSubmit'
-									disabled={
-										!touched ||
-										!values.contactIds?.length ||
-										!values.title?.length ||
-										!values.description?.length
-									}
+									disabled={!touched || !values.contactIds?.length || !values.title?.length}
 								>
 									{t('addRequestButtons.createRequest')}
 								</FormikSubmitButton>
-
-								{/* Uncomment for debugging */}
-								{/* {errors && touched && (
-									<ul>
-										{Object.keys(errors).map(err => (
-											<li>
-												{err}: {errors[err]}
-											</li>
-										))}
-									</ul>
-								)} */}
 							</Form>
 						</>
 					)

--- a/packages/webapp/src/components/forms/EditRequestForm/index.tsx
+++ b/packages/webapp/src/components/forms/EditRequestForm/index.tsx
@@ -18,7 +18,6 @@ import { ClientSelect } from '~components/ui/ClientSelect'
 import { FadeIn } from '~components/ui/FadeIn'
 import { FormSectionTitle } from '~components/ui/FormSectionTitle'
 import { FormTitle } from '~components/ui/FormTitle'
-import { FormikField } from '~components/ui/FormikField'
 import { FormikSubmitButton } from '~components/ui/FormikSubmitButton'
 import { SpecialistSelect } from '~components/ui/SpecialistSelect'
 import { TagSelect } from '~components/ui/TagSelect'
@@ -46,13 +45,8 @@ export const EditRequestForm: StandardFC<EditRequestFormProps> = wrap(function E
 	const formTitle = title || t('editRequestTitle')
 
 	const EditRequestSchema = yup.object().shape({
-		title: yup
-			.string()
-			.min(2, t('editRequestYup.tooShort'))
-			.max(200, t('editRequestYup.tooLong'))
-			.required(t('editRequestYup.required')),
-		contactIds: yup.array().min(1, t('editRequestYup.required')),
-		description: yup.string().required(t('editRequestYup.required'))
+		title: yup.string().min(2, t('editRequestYup.tooShort')).required(t('editRequestYup.required')),
+		contactIds: yup.array().min(1, t('editRequestYup.required'))
 	})
 
 	const onSaveClick = (values: any) => {
@@ -128,12 +122,11 @@ export const EditRequestForm: StandardFC<EditRequestFormProps> = wrap(function E
 							<Row className='flex-column flex-md-row mb-4'>
 								<Col className='mb-3 mb-md-0'>
 									<FormSectionTitle>{t('editRequestFields.requestTitle')}</FormSectionTitle>
-									<FormikField
+
+									<ActionInput
 										name='title'
-										placeholder={t('editRequestFields.requestTitlePlaceholder')}
-										className={cx(styles.field)}
-										error={errors?.title?.toString()}
-										errorClassName={cx(styles.errorLabel)}
+										error={get(touched, 'title') ? get(errors, 'title')?.toString() : undefined}
+										rows='1'
 									/>
 								</Col>
 							</Row>

--- a/packages/webapp/src/components/ui/ActionInput/index.tsx
+++ b/packages/webapp/src/components/ui/ActionInput/index.tsx
@@ -18,6 +18,7 @@ export interface ActionInputProps {
 	showSubmit?: boolean
 	error?: string
 	name: string
+	rows?: string
 }
 
 export const ActionInput: StandardFC<ActionInputProps> = memo(function ActionInput({
@@ -27,7 +28,8 @@ export const ActionInput: StandardFC<ActionInputProps> = memo(function ActionInp
 	actions,
 	showSubmit = false,
 	error,
-	name
+	name,
+	rows = 3
 }) {
 	const { c } = useTranslation()
 	const [focused, setFocus] = useState(false)
@@ -51,7 +53,7 @@ export const ActionInput: StandardFC<ActionInputProps> = memo(function ActionInp
 						name={name}
 						placeholder={c('actionInput.textareaPlaceholder')}
 						component='textarea'
-						rows='3'
+						rows={rows}
 					/>
 				</div>
 				{actions?.length > 0 && (


### PR DESCRIPTION
**What**
- fix #369 
- fix #310 

**How**
- Removed the need to have a description to enable the submit button
- Remove the error message if the description field is empty
- Add an `(Optional)` next to the description field title
- Remove the 200 character limit on the title field
- Make the title field a small textarea