### PR TITLE
#375 remove duplicate userId to fix reassignment bug

### DIFF
--- a/packages/webapp/src/pages/index.tsx
+++ b/packages/webapp/src/pages/index.tsx
@@ -35,8 +35,7 @@ const HomePage: FC = wrap(function Home() {
 
 	const handleEditMyEngagements = async (form: any) => {
 		await editRequest({
-			...form,
-			userId
+			...form
 		})
 	}
 


### PR DESCRIPTION
`userId` from the `form` object was being overwritten by the `userId` pulled from the `useCurrentUser` hook before being sent to the `editRequest` function from `useEngagementList`. Removing the duplicate in the call fixes everything in local testing regarding this bug without regression as far I can see.