### PR TITLE
#489 footer viewport issue fix

### DIFF
--- a/packages/webapp/src/components/ui/Footer/index.module.scss
+++ b/packages/webapp/src/components/ui/Footer/index.module.scss
@@ -11,6 +11,9 @@
 	display: flex;
 	justify-content: center;
 	padding: space(4);
+	position: sticky;
+	bottom: 0;
+	z-index: 1;
 
 	a {
 		color: color('dark');


### PR DESCRIPTION
Default/baseline footer code was missing the same kind of sticky css settings as the header already had, so I added it to the footer. Checked it at various heights, seems to keep the footer in view just like the header is.

Closes #489.