### PR TITLE
Adding a PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+**What** 
+	- Explain the changes you've made. 
+	- It doesn't need to be fancy or technical, just explicit prose on the change. 
+	- Reference a ticket in your issue if appropriate, but by all means, don't just reference the ticket. 
+
+**Why**
+	- Explain the engineering goal this change achieves but also some higher-level goal that is satisfied. 
+
+**How**
+	- Brief explanation of the approach taken and design decisions. 
+
+**Testing**
+	- Which tests have been added or updated.
+	- Explain the steps to test this change and let the reviewer also know if some conditions or edge cases were not tested, why they weren't tested, and any associated risks.
+
+**Screenshots**
+	- This applies to UI-related tasks. A simple screenshot of the before and after helps the reviewer to understand the current state vs the development state.
+
+**Anything else**
+	- You might want to call out challenges, technical debts, etc.


### PR DESCRIPTION
Adding a basic template for PR, this might help the reviewer, and act as a checklist of things to do before submitting one.