### PR TITLE
support notes on all reporting tables

### DIFF
--- a/packages/webapp/src/components/lists/ReportList/index.tsx
+++ b/packages/webapp/src/components/lists/ReportList/index.tsx
@@ -53,7 +53,8 @@ export const ReportList: StandardFC<ReportListProps> = wrap(function ReportList(
 			city: true,
 			county: true,
 			state: true,
-			zip: true
+			zip: true,
+			notes: true
 		},
 		services: {
 			gender: true,
@@ -68,7 +69,8 @@ export const ReportList: StandardFC<ReportListProps> = wrap(function ReportList(
 			city: true,
 			county: true,
 			state: true,
-			zip: true
+			zip: true,
+			notes: true
 		}
 	}
 

--- a/packages/webapp/src/components/lists/ReportList/reports/RequestReport/useRequestReportColumns/useContactFormColumns.tsx
+++ b/packages/webapp/src/components/lists/ReportList/reports/RequestReport/useRequestReportColumns/useContactFormColumns.tsx
@@ -431,6 +431,30 @@ export function useContactFormColumns(
 				sortingValue(item) {
 					return item?.contacts[0]?.address?.zip ?? -1
 				}
+			},
+			{
+				key: 'notes',
+				headerClassName: styles.headerItemCell,
+				itemClassName: styles.itemCell,
+				name: t('customFilters.notes'),
+				onRenderColumnHeader(key, name) {
+					return (
+						<CustomTextFieldFilter
+							defaultValue={getStringValue(key)}
+							filterLabel={name}
+							onFilterChanged={(value) => filterColumnTextValue(key, value)}
+							onTrackEvent={onTrackEvent}
+						/>
+					)
+				},
+				onRenderColumnItem(item: Contact) {
+					return item?.notes ?? ''
+				},
+				isSortable: true,
+				sortingFunction: sortByAlphanumeric,
+				sortingValue(contact: Contact) {
+					return contact?.notes ?? ''
+				}
 			}
 		]
 


### PR DESCRIPTION
Fixes: #495 
Fixes: #496 
Fixes: #497 

**What** 
	- Allow support for the notes field on all tables
	- Support includes rending, sorting and setting notes as a default hidden field

**Screenshots**
<img width="366" alt="Screen Shot 2022-04-06 at 2 54 12 PM" src="https://user-images.githubusercontent.com/25292393/162047855-dee5b40e-a2ff-45c9-a70c-c23b6c916807.png">
<img width="465" alt="Screen Shot 2022-04-06 at 2 54 39 PM" src="https://user-images.githubusercontent.com/25292393/162047923-1523dbfc-a0f5-4af6-b6bd-9f878a957a11.png">

