### PR TITLE
remove redundant username/password error msg

### DIFF
--- a/packages/webapp/src/components/forms/LoginForm/index.tsx
+++ b/packages/webapp/src/components/forms/LoginForm/index.tsx
@@ -15,8 +15,6 @@ import { Namespace, useTranslation } from '~hooks/useTranslation'
 import { FormSectionTitle } from '~components/ui/FormSectionTitle'
 import { wrap } from '~utils/appinsights'
 import { Checkbox } from '@fluentui/react'
-import type { MessageResponse } from '~hooks/api'
-import { StatusType } from '~hooks/api'
 import { noop } from '~utils/noop'
 import { useNavCallback } from '~hooks/useNavCallback'
 import { ApplicationRoute } from '~types/ApplicationRoute'
@@ -33,15 +31,13 @@ export const LoginForm: StandardFC<LoginFormProps> = wrap(function LoginForm({
 	const { t } = useTranslation(Namespace.Login)
 	const { login } = useAuthUser()
 	const [acceptedAgreement, setAcceptedAgreement] = useState(false)
-	const [loginMessage, setLoginMessage] = useState<MessageResponse | null>()
 
 	const handleLoginClick = useCallback(
 		async (values) => {
 			const resp = await login(values.username, values.password)
-			setLoginMessage(resp)
 			onLoginClick(resp.status)
 		},
-		[login, setLoginMessage, onLoginClick]
+		[login, onLoginClick]
 	)
 	const handlePasswordResetClick = useNavCallback(ApplicationRoute.PasswordReset)
 
@@ -68,7 +64,7 @@ export const LoginForm: StandardFC<LoginFormProps> = wrap(function LoginForm({
 					}}
 					onSubmit={handleLoginClick}
 				>
-					{({ submitCount }) => {
+					{() => {
 						return (
 							<Form>
 								<FormSectionTitle className='mb-3'>
@@ -99,9 +95,6 @@ export const LoginForm: StandardFC<LoginFormProps> = wrap(function LoginForm({
 										{t('login.forgotPasswordText')}
 									</span>
 								</Col>
-								{loginMessage?.status === StatusType.Failed && submitCount > 0 && (
-									<div className='mb-2 text-danger'>{t('login.invalidLogin')}</div>
-								)}
 								{error && <div className='mb-2 ps-1 text-danger'>{error}</div>}
 								<button
 									type='submit'

--- a/packages/webapp/src/locales/en-US/login.json
+++ b/packages/webapp/src/locales/en-US/login.json
@@ -21,8 +21,6 @@
     "emailPlaceholder": "Enter Email",
     "_emailPlaceholder.comment": "Placeholder text for email",
     "passwordPlaceholder": "Enter Password",
-    "_passwordPlaceholder.comment": "Placeholder text for password",
-    "invalidLogin": "Invalid email or password. Please try again.",
-    "_invalidLogin.comment": "Invalid text for failed login"
+    "_passwordPlaceholder.comment": "Placeholder text for password"
   }
 }

--- a/packages/webapp/src/locales/es-US/login.json
+++ b/packages/webapp/src/locales/es-US/login.json
@@ -10,7 +10,6 @@
     "passwordText": "Contraseña",
     "forgotPasswordText": "¿Olvidó su contraseña?",
     "emailPlaceholder": "Especifique el correo electrónico",
-    "passwordPlaceholder": "Escriba la contraseña",
-    "invalidLogin": "Correo electrónico o contraseña no válidos. Vuelva a intentarlo."
+    "passwordPlaceholder": "Escriba la contraseña"
   }
 }


### PR DESCRIPTION
**What** 
- Removed one of the two error messages that appear when a user enters wrong login info

**Why**
- The second error message was redundant

**How**
 - Remove code connected to error msg

**Testing**
 - This can be tested but entering incorrect info at login page

**Screenshots**
<img width="928" alt="image" src="https://user-images.githubusercontent.com/95376249/162261248-2b18d016-0672-4e2a-b0ac-8fccc040ab29.png">

