### PR TITLE
default reporting table to most recent service

### DIFF
--- a/packages/webapp/src/components/lists/ReportList/ReportOptions.tsx
+++ b/packages/webapp/src/components/lists/ReportList/ReportOptions.tsx
@@ -241,11 +241,7 @@ export const ReportOptions: FC<ReportOptionsProps> = memo(function ReportOptions
 
 	const defaultReportType = reportOptions.find((r) => r.value === type) ?? reportOptions[0]
 
-	const firstService = filterOptions
-		? filterOptions?.options
-			? filterOptions?.options[0]
-			: null
-		: null
+	const firstService = filterOptions ? filterOptions?.options?.[0] : null
 	const firstServiceOption: OptionType = firstService
 		? { value: firstService.value, label: firstService.label }
 		: null

--- a/packages/webapp/src/components/lists/ReportList/ReportOptions.tsx
+++ b/packages/webapp/src/components/lists/ReportList/ReportOptions.tsx
@@ -240,9 +240,19 @@ export const ReportOptions: FC<ReportOptionsProps> = memo(function ReportOptions
 	}, [showFieldFilters, hiddenFields, setShowFieldFiltersSelected])
 
 	const defaultReportType = reportOptions.find((r) => r.value === type) ?? reportOptions[0]
+
+	const firstService = filterOptions
+		? filterOptions?.options
+			? filterOptions?.options[0]
+			: null
+		: null
+	const firstServiceOption: OptionType = firstService
+		? { value: firstService.value, label: firstService.label }
+		: null
+
 	const defaultSelectedServiceOption: OptionType = selectedService
 		? { value: selectedService.id, label: selectedService.name }
-		: null
+		: firstServiceOption
 
 	return (
 		<header className='row mb-3 align-items-end'>

--- a/packages/webapp/src/components/lists/ReportList/index.tsx
+++ b/packages/webapp/src/components/lists/ReportList/index.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft. All rights reserved.
  * Licensed under the MIT license. See LICENSE file in the project.
  */
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useState, useMemo } from 'react'
 import styles from './index.module.scss'
 import type { StandardFC } from '~types/StandardFC'
 import { wrap, trackEvent } from '~utils/appinsights'
@@ -74,7 +74,7 @@ export const ReportList: StandardFC<ReportListProps> = wrap(function ReportList(
 		}
 	}
 
-	const preferencesObj = preferences ? JSON.parse(preferences) : {}
+	const preferencesObj = useMemo(() => (preferences ? JSON.parse(preferences) : {}), [preferences])
 
 	// Data & Filtering
 	const [unfilteredData, setUnfilteredData] = useState<unknown[]>(empty)
@@ -134,6 +134,7 @@ export const ReportList: StandardFC<ReportListProps> = wrap(function ReportList(
 			setHiddenFields(_hiddenFields)
 
 			updateUserPreferences({
+				...preferencesObj,
 				reportList: {
 					...(preferencesObj?.reportList ?? {}),
 					[reportType]: {
@@ -142,14 +143,7 @@ export const ReportList: StandardFC<ReportListProps> = wrap(function ReportList(
 				}
 			})
 		},
-		[
-			setHiddenFields,
-			hiddenFields,
-			clearFilter,
-			preferencesObj?.reportList,
-			reportType,
-			updateUserPreferences
-		]
+		[setHiddenFields, hiddenFields, clearFilter, reportType, updateUserPreferences, preferencesObj]
 	)
 
 	const areFiltersApplied = useCallback(() => {


### PR DESCRIPTION
fixes: #293 

**What** 
 - sets the default selected service when the user navigates back to the service section of the reporting page
 - if no default selected service is found, default to the first available service in the list

**How**
 - the selected service is now stored and read from the user preferences api hook

**Testing**
 - select a service
 - reload the page
 - your selected service should reappear
