### PR TITLE
Separate First and Last name from clients

### DIFF
--- a/packages/webapp/src/components/lists/ContactList/ContactTitle.tsx
+++ b/packages/webapp/src/components/lists/ContactList/ContactTitle.tsx
@@ -10,23 +10,45 @@ import { Namespace, useTranslation } from '~hooks/useTranslation'
 import { useNavCallback } from '~hooks/useNavCallback'
 import { CardRowTitle } from '~ui/CardRowTitle'
 
-export function getContactTitle(contact: Contact, t: (key: string) => string): string {
-	const name = contact.name.first + ' ' + contact.name.last
-	if (contact?.status === ContactStatus.Archived) {
-		return name + ' (' + t('archived') + ')'
-	}
-	return name
+export enum ContactName {
+	First,
+	Last,
+	Full
 }
 
-export const ContactTitle: FC<{ contact: Contact }> = memo(function ContactTitle({ contact }) {
-	const { t } = useTranslation(Namespace.Clients)
-	const handleClick = useNavCallback(null, { contact: contact.id })
-	return (
-		<CardRowTitle
-			tag='span'
-			title={getContactTitle(contact, t)}
-			titleLink='/'
-			onClick={handleClick}
-		/>
-	)
-})
+export function getContactTitle(
+	contact: Contact,
+	t: (key: string) => string,
+	name: ContactName
+): string {
+	const { first, last } = contact.name
+	const isArchived = contact?.status === ContactStatus.Archived
+
+	switch (name) {
+		case ContactName.First:
+			return first
+
+		case ContactName.Last:
+			return isArchived ? `${last} (${t('archived')})` : last
+
+		case ContactName.Full:
+		default:
+			const fullname = `${first} ${last}`
+			return isArchived ? `${fullname} (${t('archived')})` : fullname
+	}
+}
+
+export const ContactTitle: FC<{ contact: Contact; name?: ContactName }> = memo(
+	function ContactTitle({ contact, name }) {
+		const { t } = useTranslation(Namespace.Clients)
+		const handleClick = useNavCallback(null, { contact: contact.id })
+		return (
+			<CardRowTitle
+				tag='span'
+				title={getContactTitle(contact, t, name)}
+				titleLink='/'
+				onClick={handleClick}
+			/>
+		)
+	}
+)

--- a/packages/webapp/src/components/lists/ContactList/columns.tsx
+++ b/packages/webapp/src/components/lists/ContactList/columns.tsx
@@ -7,7 +7,7 @@ import type { Contact } from '@cbosuite/schema/dist/client-types'
 import type { IPaginatedListColumn } from '~components/ui/PaginatedList'
 import type { IMultiActionButtons } from '~components/ui/MultiActionButton2'
 import { MultiActionButton } from '~components/ui/MultiActionButton2'
-import { ContactTitle, getContactTitle } from './ContactTitle'
+import { ContactName, ContactTitle, getContactTitle } from './ContactTitle'
 import { MobileContactCard } from './MobileContactCard'
 import { EngagementStatusText, getEngagementStatusText } from './EngagementStatusText'
 import { GenderText, getGenderText } from './GenderText'
@@ -23,15 +23,27 @@ export function usePageColumns(actions: IMultiActionButtons<Contact>[]): IPagina
 	return useMemo(
 		() => [
 			{
-				key: 'name',
-				name: t('clientList.columns.name'),
+				key: 'firstname',
+				name: t('clientList.columns.firstname'),
 				onRenderColumnItem(contact: Contact) {
-					return <ContactTitle contact={contact} />
+					return <ContactTitle contact={contact} name={ContactName.First} />
 				},
 				isSortable: true,
 				sortingFunction: sortByAlphanumeric,
 				sortingValue(contact: Contact) {
-					return getContactTitle(contact, t)
+					return getContactTitle(contact, t, ContactName.First)
+				}
+			},
+			{
+				key: 'lastname',
+				name: t('clientList.columns.lastname'),
+				onRenderColumnItem(contact: Contact) {
+					return <ContactTitle contact={contact} name={ContactName.Last} />
+				},
+				isSortable: true,
+				sortingFunction: sortByAlphanumeric,
+				sortingValue(contact: Contact) {
+					return getContactTitle(contact, t, ContactName.Last)
 				}
 			},
 			{
@@ -68,7 +80,6 @@ export function usePageColumns(actions: IMultiActionButtons<Contact>[]): IPagina
 			{
 				key: 'gender',
 				name: t('demographics.gender.label'),
-				className: 'col-2',
 				onRenderColumnItem(contact: Contact) {
 					return <GenderText gender={contact?.demographics?.gender} />
 				},
@@ -81,7 +92,6 @@ export function usePageColumns(actions: IMultiActionButtons<Contact>[]): IPagina
 			{
 				key: 'race',
 				name: t('demographics.race.label'),
-				className: 'col-2',
 				onRenderColumnItem(contact: Contact) {
 					return <RaceText race={contact?.demographics?.race} />
 				},

--- a/packages/webapp/src/components/lists/ReportList/reports/ClientReport/useClientReportColumns.tsx
+++ b/packages/webapp/src/components/lists/ReportList/reports/ClientReport/useClientReportColumns.tsx
@@ -17,7 +17,7 @@ import { useRecoilValue } from 'recoil'
 import { fieldFiltersState, organizationState } from '~store'
 import styles from '../../index.module.scss'
 import { useGetValue } from '../../hooks'
-import { getContactTitle } from '~components/lists/ContactList/ContactTitle'
+import { ContactName, getContactTitle } from '~components/lists/ContactList/ContactTitle'
 import { sortByAlphanumeric, sortByDate, sortByTags } from '~utils/sorting'
 
 export function useClientReportColumns(
@@ -37,10 +37,10 @@ export function useClientReportColumns(
 	return useMemo((): IPaginatedTableColumn[] => {
 		const _pageColumns: IPaginatedTableColumn[] = [
 			{
-				key: 'name',
+				key: 'firstname',
 				headerClassName: styles.headerItemCell,
 				itemClassName: styles.itemCell,
-				name: t('clientList.columns.name'),
+				name: t('clientList.columns.firstname'),
 				onRenderColumnHeader(key, name) {
 					return (
 						<CustomTextFieldFilter
@@ -52,12 +52,36 @@ export function useClientReportColumns(
 					)
 				},
 				onRenderColumnItem(item: Contact) {
-					return `${item?.name?.first} ${item?.name?.last}`
+					return item?.name?.first
 				},
 				isSortable: true,
 				sortingFunction: sortByAlphanumeric,
 				sortingValue(contact: Contact) {
-					return getContactTitle(contact, t)
+					return getContactTitle(contact, t, ContactName.First)
+				}
+			},
+			{
+				key: 'lastname',
+				headerClassName: styles.headerItemCell,
+				itemClassName: styles.itemCell,
+				name: t('clientList.columns.lastname'),
+				onRenderColumnHeader(key, name) {
+					return (
+						<CustomTextFieldFilter
+							defaultValue={getStringValue(key)}
+							filterLabel={name}
+							onFilterChanged={(value) => filterColumnTextValue(key, value)}
+							onTrackEvent={onTrackEvent}
+						/>
+					)
+				},
+				onRenderColumnItem(item: Contact) {
+					return item?.name?.last
+				},
+				isSortable: true,
+				sortingFunction: sortByAlphanumeric,
+				sortingValue(contact: Contact) {
+					return getContactTitle(contact, t, ContactName.Last)
 				}
 			},
 			{

--- a/packages/webapp/src/components/lists/ReportList/reports/RequestReport/useRequestReportColumns/useContactFormColumns.tsx
+++ b/packages/webapp/src/components/lists/ReportList/reports/RequestReport/useRequestReportColumns/useContactFormColumns.tsx
@@ -35,10 +35,10 @@ export function useContactFormColumns(
 	return useMemo(() => {
 		const columns = [
 			{
-				key: 'name',
+				key: 'firstname',
 				headerClassName: styles.headerItemCell,
 				itemClassName: styles.itemCell,
-				name: t('clientList.columns.name'),
+				name: t('clientList.columns.firstname'),
 				onRenderColumnHeader(key, name) {
 					return (
 						<CustomTextFieldFilter
@@ -50,12 +50,36 @@ export function useContactFormColumns(
 					)
 				},
 				onRenderColumnItem(item) {
-					return `${item?.contacts[0]?.name?.first} ${item?.contacts[0]?.name?.last}`
+					return item?.contacts[0]?.name?.first
 				},
 				isSortable: true,
 				sortingFunction: sortByAlphanumeric,
 				sortingValue(item) {
-					return `${item?.contacts[0]?.name?.first} ${item?.contacts[0]?.name?.last}`
+					return item?.contacts[0]?.name?.first
+				}
+			},
+			{
+				key: 'lastname',
+				headerClassName: styles.headerItemCell,
+				itemClassName: styles.itemCell,
+				name: t('clientList.columns.lastname'),
+				onRenderColumnHeader(key, name) {
+					return (
+						<CustomTextFieldFilter
+							defaultValue={getStringValue(key)}
+							filterLabel={name}
+							onFilterChanged={(value) => filterColumnTextValue(key, value)}
+							onTrackEvent={onTrackEvent}
+						/>
+					)
+				},
+				onRenderColumnItem(item) {
+					return item?.contacts[0]?.name?.last
+				},
+				isSortable: true,
+				sortingFunction: sortByAlphanumeric,
+				sortingValue(item) {
+					return item?.contacts[0]?.name?.last
 				}
 			},
 			{

--- a/packages/webapp/src/locales/en-US/clients.json
+++ b/packages/webapp/src/locales/en-US/clients.json
@@ -9,6 +9,10 @@
     "columns": {
       "name": "Name",
       "_name.comment": "Name column header label of the list",
+      "firstname": "First name",
+      "_firstname.comment": "First Name column header label of the list",
+      "lastname": "Last name",
+      "_lastname.comment": "Last Name column header label of the list",
       "requests": "Requests",
       "_requests.comment": "Requests column header label of the list",
       "tags": "Tags",

--- a/packages/webapp/src/locales/es-US/clients.json
+++ b/packages/webapp/src/locales/es-US/clients.json
@@ -5,6 +5,8 @@
   "clientList": {
     "columns": {
       "name": "Nombre",
+      "firstname": "Nombre",
+      "lastname": "Apellido",
       "requests": "Solicitudes",
       "tags": "Etiquetas"
     },


### PR DESCRIPTION
**What** 
 - Display clients _first_ and _last_ names in differents columns.

**Why**
 - To help sort client by last name.
 - fix #409 

**How**
 - Added an _enum_ to select which values to return from the Contact Utils.
 - Split the `Name` column into a `first name` and `last name` on the _Client_ and _Reporting_ pages.

**Screenshots**
<img width="468" alt="Screen Shot 2022-04-12 at 16 04 31" src="https://user-images.githubusercontent.com/636801/163044476-e407567c-fe15-42b5-a1f6-c32fab8c870d.png">
<img width="446" alt="Screen Shot 2022-04-12 at 16 04 38" src="https://user-images.githubusercontent.com/636801/163044482-68ae202c-b838-4782-9d4b-c1ea1753554f.png">
<img width="605" alt="Screen Shot 2022-04-12 at 16 04 43" src="https://user-images.githubusercontent.com/636801/163044488-0225456e-d7cb-47df-8831-617653e64aef.png">
<img width="504" alt="Screen Shot 2022-04-12 at 16 04 48" src="https://user-images.githubusercontent.com/636801/163044491-46d5f0b3-d076-4a2c-8254-2e9614161fb2.png">
