### PR TITLE
Feature/314 - Improve Nav Bar Responsiveness & Update Account Layout

### DIFF
--- a/packages/acceptance-tests/test/pageobjects/Header.ts
+++ b/packages/acceptance-tests/test/pageobjects/Header.ts
@@ -14,9 +14,6 @@ const selectors: Record<string, string> = {
 	clientsLink: '.topNavClients',
 	tagsLink: '.topNavTags',
 	reportingLink: '.topNavReporting',
-	languageDropdown: '#languageDropdown',
-	englishButton: '#languageDropdown-list0',
-	spanishButton: '#languageDropdown-list1',
 	notificationsBell: '#notifications-bell',
 	notificationsPanel: '#notifications-panel'
 }
@@ -70,18 +67,6 @@ export class Header extends Page {
 
 	public async clickReportingLink() {
 		await this.page.click(selectors.reportingLink)
-	}
-
-	public async clickLanguageDropdown() {
-		await this.page.click(selectors.languageDropdown)
-	}
-
-	public async clickEnglishButton() {
-		await this.page.click(selectors.englishButton)
-	}
-
-	public async clickSpanishButton() {
-		await this.page.click(selectors.spanishButton)
 	}
 
 	public async clickNotificationsBell() {

--- a/packages/acceptance-tests/test/pageobjects/Header.ts
+++ b/packages/acceptance-tests/test/pageobjects/Header.ts
@@ -5,7 +5,7 @@
 import { Page } from './Page'
 
 const selectors: Record<string, string> = {
-	btnMenu: '.personaMenuContainer',
+	btnMenu: '.persona',
 	btnLogout: '.logout',
 	btnViewAccount: '.view-account',
 	dashboardLink: 'nav [href="/"]',

--- a/packages/acceptance-tests/test/pageobjects/Header.ts
+++ b/packages/acceptance-tests/test/pageobjects/Header.ts
@@ -5,7 +5,7 @@
 import { Page } from './Page'
 
 const selectors: Record<string, string> = {
-	btnMenu: '.persona',
+	btnMenu: '.personaMenuContainer',
 	btnLogout: '.logout',
 	btnViewAccount: '.view-account',
 	dashboardLink: 'nav [href="/"]',

--- a/packages/acceptance-tests/test/pageobjects/ProfilePage.ts
+++ b/packages/acceptance-tests/test/pageobjects/ProfilePage.ts
@@ -5,7 +5,10 @@
 import { Page } from './Page'
 
 const selectors: Record<string, string> = {
-	form: '.profileForm'
+	form: '.profileForm',
+	languageDropdown: '#languageDropdown',
+	englishButton: '#languageDropdown-list0',
+	spanishButton: '#languageDropdown-list1'
 }
 export class ProfilePage extends Page {
 	public async waitForLoad() {
@@ -15,5 +18,17 @@ export class ProfilePage extends Page {
 
 	public open() {
 		return super.open('account')
+	}
+
+	public async clickLanguageDropdown() {
+		await this.page.click(selectors.languageDropdown)
+	}
+
+	public async clickEnglishButton() {
+		await this.page.click(selectors.englishButton)
+	}
+
+	public async clickSpanishButton() {
+		await this.page.click(selectors.spanishButton)
 	}
 }

--- a/packages/acceptance-tests/test/pageobjects/index.ts
+++ b/packages/acceptance-tests/test/pageobjects/index.ts
@@ -88,12 +88,12 @@ export function createPageObjects(page: Page): PageObjects {
 				await dashboardPage.waitForLoad()
 			},
 			selectSpanishLanguage: async () => {
-				await header.clickLanguageDropdown()
-				await header.clickSpanishButton()
+				await profilePage.clickLanguageDropdown()
+				await profilePage.clickSpanishButton()
 			},
 			selectEnglishLanguage: async () => {
-				await header.clickLanguageDropdown()
-				await header.clickEnglishButton()
+				await profilePage.clickLanguageDropdown()
+				await profilePage.clickEnglishButton()
 			}
 		}
 	}

--- a/packages/acceptance-tests/test/specs/header.spec.ts
+++ b/packages/acceptance-tests/test/specs/header.spec.ts
@@ -4,7 +4,7 @@
  */
 /* eslint-disable jest/expect-expect,jest/no-done-callback */
 import type { Page } from '@playwright/test'
-import { test, expect } from '@playwright/test'
+import { test } from '@playwright/test'
 import type { PageObjects } from '../pageobjects'
 import { createPageObjects } from '../pageobjects'
 

--- a/packages/acceptance-tests/test/specs/header.spec.ts
+++ b/packages/acceptance-tests/test/specs/header.spec.ts
@@ -63,22 +63,6 @@ test.describe('The application header', () => {
 		await po.notFoundPage.waitForLoad()
 	})
 
-	test('can switch between languages', async ({ page }) => {
-		await po.dashboardPage.open()
-		await po.dashboardPage.waitForLoad()
-		await po.sequences.selectSpanishLanguage()
-		await po.dashboardPage.waitForLoad()
-
-		let createRequestLabelText = await po.dashboardPage.getNewRequestLabel()
-		expect(createRequestLabelText).toContain('Crear una solicitud')
-
-		await po.sequences.selectEnglishLanguage()
-		await po.dashboardPage.waitForLoad()
-
-		createRequestLabelText = await po.dashboardPage.getNewRequestLabel()
-		expect(createRequestLabelText).toContain('Create a Request')
-	})
-
 	test('can show notifications pane', async () => {
 		await po.header.clickNotificationsBell()
 		await po.header.waitForNotificationsPanelToShow()

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "clean": "essex clean .version dist/ out/ node_modules/.cache/ public/localizations public/workers",
-    "start": "yarn write_version && NODE_CONFIG_ENV=development vite -c vite.config.js",
+    "start": "yarn write_version && NyarnODE_CONFIG_ENV=development vite -c vite.config.js",
     "start:webapp": "yarn start",
     "start:webapp:static": "http-server dist -p 3000",
     "typecheck": "tsc -b .",

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "clean": "essex clean .version dist/ out/ node_modules/.cache/ public/localizations public/workers",
-    "start": "yarn write_version && NyarnODE_CONFIG_ENV=development vite -c vite.config.js",
+    "start": "yarn write_version && NODE_CONFIG_ENV=development vite -c vite.config.js",
     "start:webapp": "yarn start",
     "start:webapp:static": "http-server dist -p 3000",
     "typecheck": "tsc -b .",

--- a/packages/webapp/src/components/forms/ProfileForm/index.tsx
+++ b/packages/webapp/src/components/forms/ProfileForm/index.tsx
@@ -12,6 +12,7 @@ import { FormikSubmitButton } from '~components/ui/FormikSubmitButton'
 import { FormikButton } from '~components/ui/FormikButton'
 import { FormikField } from '~ui/FormikField'
 import { Formik, Form } from 'formik'
+import { LanguageDropdown } from '~ui/LanguageDropdown'
 import { useProfile } from '~hooks/api/useProfile'
 import { useCallback, useState } from 'react'
 import { useSpecialist } from '~hooks/api/useSpecialist'
@@ -109,6 +110,9 @@ export const ProfileForm: StandardFC<ProfileFormProps> = wrap(function ProfileFo
 			<Row className='align-items-center mb-3'>
 				<Col>
 					<h2 className='d-flex align-items-center'>{t('account.header.title')}</h2>
+				</Col>
+				<Col lg='3'>
+					<LanguageDropdown />
 				</Col>
 			</Row>
 			<Row className={cx('g-0 pt-4 pb-3', styles.subHeaderContainer)}>

--- a/packages/webapp/src/components/forms/ProfileForm/index.tsx
+++ b/packages/webapp/src/components/forms/ProfileForm/index.tsx
@@ -107,15 +107,10 @@ export const ProfileForm: StandardFC<ProfileFormProps> = wrap(function ProfileFo
 
 	return (
 		<Col className='mt-5 mb-5 profileForm'>
-			<Row className='align-items-center mb-3'>
-				<Col>
-					<h2 className='d-flex align-items-center'>{t('account.header.title')}</h2>
-				</Col>
-				<Col lg='3'>
-					<LanguageDropdown />
-				</Col>
+			<Row className='mb-3'>
+				<h2>{t('account.header.title')}</h2>
 			</Row>
-			<Row className={cx('g-0 pt-4 pb-3', styles.subHeaderContainer)}>
+			<Row className={cx('mb-3', styles.subHeaderContainer)}>
 				<Col md={3} sm={12}>
 					{t('account.header.userName')}:{' '}
 					<span className='text-primary'>
@@ -133,281 +128,259 @@ export const ProfileForm: StandardFC<ProfileFormProps> = wrap(function ProfileFo
 					{t('account.header.totalEngagementCompleted')}:{' '}
 					<strong>{user?.engagementCounts?.closed || 0}</strong>
 				</Col>
-				<Col></Col>
 			</Row>
 			<Row>
-				<Formik
-					initialValues={{
-						firstName: user?.name?.first || emptyStr,
-						middleName: user?.name?.middle || emptyStr,
-						lastName: user?.name?.last || emptyStr,
-						description: user?.description || emptyStr,
-						additionalInfo: user?.additionalInfo || emptyStr,
-						email: user?.email || emptyStr,
-						phone: user?.phone || emptyStr,
-						street: user?.address?.street || emptyStr,
-						unit: user?.address?.unit || emptyStr,
-						city: user?.address?.city || emptyStr,
-						state: user?.address?.state || emptyStr,
-						zip: user?.address?.zip || emptyStr
-					}}
-					onSubmit={(values) => {
-						saveUserProfile(values)
-					}}
-					validationSchema={profileSchema}
-				>
-					{({ errors }) => {
-						return (
-							<Form>
-								<Row>
-									<Col md={5} sm={12} className={isMD ? 'me-5' : null}>
-										<FormSectionTitle className='mt-5 mb-3'>
-											{t('account.fields.nameInfo')}
-										</FormSectionTitle>
-										<Row className='mb-4 pb-2'>
-											<Col>
-												<FormikField
-													name='firstName'
-													placeholder={t('account.fields.firstNamePlaceholder')}
-													className={cx(styles.field)}
-													error={errors.firstName}
-													errorClassName={cx(styles.errorLabel)}
-												/>
-												<FormikField
-													name='middleName'
-													placeholder={t('account.fields.middleNamePlaceholder')}
-													className={cx(styles.field)}
-													error={errors.middleName}
-													errorClassName={cx(styles.errorLabel)}
-												/>
-												<FormikField
-													name='lastName'
-													placeholder={t('account.fields.lastNamePlaceholder')}
-													className={cx(styles.field)}
-													error={errors.lastName}
-													errorClassName={cx(styles.errorLabel)}
-												/>
-											</Col>
-										</Row>
-										<FormSectionTitle className='mt-1 mb-3'>
-											{t('account.fields.bioInfo')}
-										</FormSectionTitle>
-										<Row className='mb-4 pb-2'>
-											<Col>
-												<FormikField
-													as='textarea'
-													name='description'
-													placeholder={t('account.fields.myBioPlaceholder')}
-													className={cx(styles.field, styles.textareaField)}
-													error={errors.description}
-													errorClassName={cx(styles.errorLabel)}
-												/>
-											</Col>
-										</Row>
-										<FormSectionTitle className='mt-1 mb-3'>
-											{t('account.fields.trainingsAchivementInfo')}
-										</FormSectionTitle>
-										<Row className={isMD ? 'mb-4 pb-2' : null}>
-											<Col>
-												<FormikField
-													as='textarea'
-													name='additionalInfo'
-													placeholder={t('account.fields.trainingAchievementPlaceholder')}
-													className={cx(styles.field, styles.textareaField)}
-													error={errors.additionalInfo}
-													errorClassName={cx(styles.errorLabel)}
-												/>
-											</Col>
-										</Row>
-										{isMD && (
-											<Row>
-												<Col>
-													<FormikSubmitButton
-														className={cx(styles.submitButton)}
-														disabled={Object.keys(errors).length > 0}
-													>
-														{t('account.buttons.save')}
-													</FormikSubmitButton>
-													{saveMessage &&
-														(saveMessage.status === StatusType.Success ? (
-															<div className={cx('mt-5 alert alert-success')}>
-																{t('account.submitMessage.success')}
-															</div>
-														) : (
-															<div className={cx('mt-5 alert alert-danger')}>
-																{t('account.submitMessage.failed')}
-															</div>
-														))}
-												</Col>
-											</Row>
-										)}
-									</Col>
-									<Col md={4} sm={12} className={isMD ? 'ms-5' : null}>
-										<FormSectionTitle className='mt-5 mb-3'>
-											{t('account.fields.contactInfo')}
-										</FormSectionTitle>
-										<Row className='mb-4 pb-2'>
-											<Col>
-												<FormikField
-													name='email'
-													placeholder={t('account.fields.emailPlaceholder')}
-													className={cx(styles.field)}
-													error={errors.email}
-													errorClassName={cx(styles.errorLabel)}
-												/>
-												<FormikField
-													name='phone'
-													placeholder={t('account.fields.phonePlaceholder')}
-													className={cx(styles.field)}
-													error={errors.phone}
-													errorClassName={cx(styles.errorLabel)}
-												/>
-											</Col>
-										</Row>
-										<FormSectionTitle className='mt-5 mb-3'>
-											{t('account.fields.address')}
-										</FormSectionTitle>
-										<Row>
-											<Col md={8}>
-												<FormikField
-													name='street'
-													placeholder={t('account.fields.streetPlaceholder')}
-													className={cx(styles.field)}
-													error={errors.street}
-													errorClassName={cx(styles.errorLabel)}
-												/>
-											</Col>
-											<Col md={4}>
-												<FormikField
-													name='unit'
-													placeholder={t('account.fields.unitPlaceholder')}
-													className={cx(styles.field)}
-													error={errors.unit}
-													errorClassName={cx(styles.errorLabel)}
-												/>
-											</Col>
-										</Row>
-										<Row className='mb-4 pb-2'>
-											<Col>
-												<FormikField
-													name='city'
-													placeholder={t('account.fields.cityPlaceholder')}
-													className={cx(styles.field)}
-													error={errors.city}
-													errorClassName={cx(styles.errorLabel)}
-												/>
-											</Col>
-											<Col md={2}>
-												<FormikField
-													name='state'
-													placeholder={t('account.fields.statePlaceHolder')}
-													className={cx(styles.field)}
-													error={errors.state}
-													errorClassName={cx(styles.errorLabel)}
-												/>
-											</Col>
-											<Col md={4}>
-												<FormikField
-													name='zip'
-													placeholder={t('account.fields.zipCodePlaceholder')}
-													className={cx(styles.field)}
-													error={errors.zip}
-													errorClassName={cx(styles.errorLabel)}
-												/>
-											</Col>
-										</Row>
-										{!isMD && (
-											<Row>
-												<Col>
-													<FormikSubmitButton
-														className={cx(styles.submitButton)}
-														disabled={Object.keys(errors).length > 0}
-													>
-														{t('account.buttons.save')}
-													</FormikSubmitButton>
-													{saveMessage &&
-														(saveMessage.status === StatusType.Success ? (
-															<div className={cx('mt-5 alert alert-success')}>
-																{t('account.submitMessage.success')}
-															</div>
-														) : (
-															<div className={cx('mt-5 alert alert-danger')}>
-																{t('account.submitMessage.failed')}
-															</div>
-														))}
-												</Col>
-											</Row>
-										)}
-									</Col>
-								</Row>
-							</Form>
-						)
-					}}
-				</Formik>
-				<Formik
-					initialValues={{
-						currentPassword: '',
-						newPassword: '',
-						confirmNewPassword: ''
-					}}
-					validationSchema={changePasswordSchema}
-					onSubmit={setPasswordCallback}
-				>
-					{({ errors }) => {
-						return (
-							<Form>
-								<FormSectionTitle className='mt-5 mb-3'>
-									{t('account.fields.passwordInfo')}
-								</FormSectionTitle>
-								<Row className='mb-4 pb-2'>
-									<Col md={5} sm={12}>
-										<FormikField
-											name='currentPassword'
-											type='password'
-											placeholder={t('account.fields.currentPasswordPlaceholder')}
-											className={cx(styles.field)}
-											error={errors.currentPassword as string}
-											errorClassName={cx(styles.errorLabel)}
-										/>
-										<FormikField
-											name='newPassword'
-											type='password'
-											placeholder={t('account.fields.newPasswordPlaceholder')}
-											className={cx(styles.field)}
-											error={errors.newPassword as string}
-											errorClassName={cx(styles.errorLabel)}
-										/>
-										<FormikField
-											name='confirmNewPassword'
-											type='password'
-											placeholder={t('account.fields.confirmPasswordPlaceholder')}
-											className={cx(styles.field)}
-											error={errors.confirmNewPassword as string}
-											errorClassName={cx(styles.errorLabel)}
-										/>
-										<FormikButton
-											type='submit'
-											disabled={Object.keys(errors).length > 0}
-											className={cx('mt-5', styles.changePasswordButton)}
-										>
-											{t('account.buttons.changePassword')}
-										</FormikButton>
-										{passwordMessage &&
-											(passwordMessage.status === StatusType.Success ? (
-												<div className={cx('mt-5 alert alert-success')}>
-													{t('account.changePasswordMessage.success')}
-												</div>
-											) : (
-												<div className={cx('mt-5 alert alert-danger')}>
-													{t('account.changePasswordMessage.failed')}
-												</div>
-											))}
-									</Col>
-								</Row>
-							</Form>
-						)
-					}}
-				</Formik>
+				<Col md={6} sm={12}>
+					<h2 className='mb-3'>{t('account.header.profile')}</h2>
+					<Formik
+						initialValues={{
+							firstName: user?.name?.first || emptyStr,
+							middleName: user?.name?.middle || emptyStr,
+							lastName: user?.name?.last || emptyStr,
+							description: user?.description || emptyStr,
+							additionalInfo: user?.additionalInfo || emptyStr,
+							email: user?.email || emptyStr,
+							phone: user?.phone || emptyStr,
+							street: user?.address?.street || emptyStr,
+							unit: user?.address?.unit || emptyStr,
+							city: user?.address?.city || emptyStr,
+							state: user?.address?.state || emptyStr,
+							zip: user?.address?.zip || emptyStr
+						}}
+						onSubmit={(values) => {
+							saveUserProfile(values)
+						}}
+						validationSchema={profileSchema}
+					>
+						{({ errors }) => {
+							return (
+								<Form>
+									<FormSectionTitle className='mt-5 mb-3'>
+										{t('account.fields.nameInfo')}
+									</FormSectionTitle>
+									<Row className='mb-4 pb-2'>
+										<Col>
+											<FormikField
+												name='firstName'
+												placeholder={t('account.fields.firstNamePlaceholder')}
+												className={cx(styles.field)}
+												error={errors.firstName}
+												errorClassName={cx(styles.errorLabel)}
+											/>
+											<FormikField
+												name='middleName'
+												placeholder={t('account.fields.middleNamePlaceholder')}
+												className={cx(styles.field)}
+												error={errors.middleName}
+												errorClassName={cx(styles.errorLabel)}
+											/>
+											<FormikField
+												name='lastName'
+												placeholder={t('account.fields.lastNamePlaceholder')}
+												className={cx(styles.field)}
+												error={errors.lastName}
+												errorClassName={cx(styles.errorLabel)}
+											/>
+										</Col>
+									</Row>
+									<FormSectionTitle className='mt-5 mb-3'>
+										{t('account.fields.address')}
+									</FormSectionTitle>
+									<Row>
+										<Col md={8}>
+											<FormikField
+												name='street'
+												placeholder={t('account.fields.streetPlaceholder')}
+												className={cx(styles.field)}
+												error={errors.street}
+												errorClassName={cx(styles.errorLabel)}
+											/>
+										</Col>
+										<Col md={4}>
+											<FormikField
+												name='unit'
+												placeholder={t('account.fields.unitPlaceholder')}
+												className={cx(styles.field)}
+												error={errors.unit}
+												errorClassName={cx(styles.errorLabel)}
+											/>
+										</Col>
+									</Row>
+									<Row className='mb-4 pb-2'>
+										<Col>
+											<FormikField
+												name='city'
+												placeholder={t('account.fields.cityPlaceholder')}
+												className={cx(styles.field)}
+												error={errors.city}
+												errorClassName={cx(styles.errorLabel)}
+											/>
+										</Col>
+										<Col md={2}>
+											<FormikField
+												name='state'
+												placeholder={t('account.fields.statePlaceHolder')}
+												className={cx(styles.field)}
+												error={errors.state}
+												errorClassName={cx(styles.errorLabel)}
+											/>
+										</Col>
+										<Col md={4}>
+											<FormikField
+												name='zip'
+												placeholder={t('account.fields.zipCodePlaceholder')}
+												className={cx(styles.field)}
+												error={errors.zip}
+												errorClassName={cx(styles.errorLabel)}
+											/>
+										</Col>
+									</Row>
+									<FormSectionTitle className='mt-1 mb-3'>
+										{t('account.fields.bioInfo')}
+									</FormSectionTitle>
+									<Row className='mb-4 pb-2'>
+										<Col>
+											<FormikField
+												as='textarea'
+												name='description'
+												placeholder={t('account.fields.myBioPlaceholder')}
+												className={cx(styles.field, styles.textareaField)}
+												error={errors.description}
+												errorClassName={cx(styles.errorLabel)}
+											/>
+										</Col>
+									</Row>
+									<FormSectionTitle className='mt-1 mb-3'>
+										{t('account.fields.trainingsAchivementInfo')}
+									</FormSectionTitle>
+									<Row className={isMD ? 'mb-4 pb-2' : null}>
+										<Col>
+											<FormikField
+												as='textarea'
+												name='additionalInfo'
+												placeholder={t('account.fields.trainingAchievementPlaceholder')}
+												className={cx(styles.field, styles.textareaField)}
+												error={errors.additionalInfo}
+												errorClassName={cx(styles.errorLabel)}
+											/>
+										</Col>
+									</Row>
+									<FormSectionTitle className='mt-5 mb-3'>
+										{t('account.fields.contactInfo')}
+									</FormSectionTitle>
+									<Row className='mb-4 pb-2'>
+										<Col>
+											<FormikField
+												name='email'
+												placeholder={t('account.fields.emailPlaceholder')}
+												className={cx(styles.field)}
+												error={errors.email}
+												errorClassName={cx(styles.errorLabel)}
+											/>
+											<FormikField
+												name='phone'
+												placeholder={t('account.fields.phonePlaceholder')}
+												className={cx(styles.field)}
+												error={errors.phone}
+												errorClassName={cx(styles.errorLabel)}
+											/>
+										</Col>
+									</Row>
+
+									<Row>
+										<Col>
+											<FormikSubmitButton
+												className={cx(styles.submitButton)}
+												disabled={Object.keys(errors).length > 0}
+											>
+												{t('account.buttons.save')}
+											</FormikSubmitButton>
+											{saveMessage &&
+												(saveMessage.status === StatusType.Success ? (
+													<div className={cx('mt-5 alert alert-success')}>
+														{t('account.submitMessage.success')}
+													</div>
+												) : (
+													<div className={cx('mt-5 alert alert-danger')}>
+														{t('account.submitMessage.failed')}
+													</div>
+												))}
+										</Col>
+									</Row>
+								</Form>
+							)
+						}}
+					</Formik>
+				</Col>
+				<Col md={6} sm={12}>
+					<h2 className='mb-3'>{t('account.header.settings')}</h2>
+					<h5 className='mt-5 mb-3'>{t('account.fields.language')}</h5>
+					<LanguageDropdown />
+					<Formik
+						initialValues={{
+							currentPassword: '',
+							newPassword: '',
+							confirmNewPassword: ''
+						}}
+						validationSchema={changePasswordSchema}
+						onSubmit={setPasswordCallback}
+					>
+						{({ errors }) => {
+							return (
+								<Form>
+									<FormSectionTitle className='mt-5 mb-3'>
+										{t('account.fields.passwordInfo')}
+									</FormSectionTitle>
+									<Row className='mb-4 pb-2'>
+										<Col md={5} sm={12}>
+											<FormikField
+												name='currentPassword'
+												type='password'
+												placeholder={t('account.fields.currentPasswordPlaceholder')}
+												className={cx(styles.field)}
+												error={errors.currentPassword as string}
+												errorClassName={cx(styles.errorLabel)}
+											/>
+											<FormikField
+												name='newPassword'
+												type='password'
+												placeholder={t('account.fields.newPasswordPlaceholder')}
+												className={cx(styles.field)}
+												error={errors.newPassword as string}
+												errorClassName={cx(styles.errorLabel)}
+											/>
+											<FormikField
+												name='confirmNewPassword'
+												type='password'
+												placeholder={t('account.fields.confirmPasswordPlaceholder')}
+												className={cx(styles.field)}
+												error={errors.confirmNewPassword as string}
+												errorClassName={cx(styles.errorLabel)}
+											/>
+											<FormikButton
+												type='submit'
+												disabled={Object.keys(errors).length > 0}
+												className={cx('mt-5', styles.changePasswordButton)}
+											>
+												{t('account.buttons.changePassword')}
+											</FormikButton>
+											{passwordMessage &&
+												(passwordMessage.status === StatusType.Success ? (
+													<div className={cx('mt-5 alert alert-success')}>
+														{t('account.changePasswordMessage.success')}
+													</div>
+												) : (
+													<div className={cx('mt-5 alert alert-danger')}>
+														{t('account.changePasswordMessage.failed')}
+													</div>
+												))}
+										</Col>
+									</Row>
+								</Form>
+							)
+						}}
+					</Formik>
+				</Col>
 			</Row>
 		</Col>
 	)

--- a/packages/webapp/src/components/ui/ActionBar/index.tsx
+++ b/packages/webapp/src/components/ui/ActionBar/index.tsx
@@ -23,7 +23,7 @@ export interface ActionBarProps {
  * Top Level action bar
  */
 export const ActionBar: StandardFC<ActionBarProps> = memo(function ActionBar({ title }) {
-	const { isMD, isLG } = useWindowSize()
+	const { isMD } = useWindowSize()
 	const { c } = useTranslation()
 
 	const showEnvironmentInfo = 'show-environment-info'

--- a/packages/webapp/src/components/ui/ActionBar/index.tsx
+++ b/packages/webapp/src/components/ui/ActionBar/index.tsx
@@ -13,7 +13,6 @@ import { ContainerRowColumn as CRC } from '~ui/CRC'
 import { PersonalNav } from '~ui/PersonalNav'
 import { TopNav } from '~ui/TopNav'
 import { Notifications } from '~ui/Notifications'
-import { LanguageDropdown } from '../LanguageDropdown'
 import { useTranslation } from '~hooks/useTranslation'
 
 export interface ActionBarProps {
@@ -24,7 +23,7 @@ export interface ActionBarProps {
  * Top Level action bar
  */
 export const ActionBar: StandardFC<ActionBarProps> = memo(function ActionBar({ title }) {
-	const { isLG } = useWindowSize()
+	const { isMD, isLG } = useWindowSize()
 	const { c } = useTranslation()
 
 	const showEnvironmentInfo = 'show-environment-info'
@@ -47,10 +46,9 @@ export const ActionBar: StandardFC<ActionBarProps> = memo(function ActionBar({ t
 						<Link href='/' className={styles.actionBarTitle}>
 							{isEmpty(title) ? c('app.title') : title}
 						</Link>
-						{isLG && <TopNav />}
+						{isMD && <TopNav />}
 					</div>
 					<div className='d-flex justify-content-between align-items-center'>
-						<LanguageDropdown />
 						<Notifications />
 						<PersonalNav />
 					</div>

--- a/packages/webapp/src/components/ui/LanguageDropdown/index.tsx
+++ b/packages/webapp/src/components/ui/LanguageDropdown/index.tsx
@@ -36,6 +36,7 @@ export const LanguageDropdown: FC<{ className?: string }> = memo(function Langua
 			options={localeOptions}
 			selectedKey={locale}
 			role='button'
+			label={c('language')}
 			ariaLabel={c('languageDropdownAriaLabel')}
 			onChange={handleChange}
 			className={cx(className)}
@@ -44,7 +45,6 @@ export const LanguageDropdown: FC<{ className?: string }> = memo(function Langua
 					? () => <FontIcon iconName='LocaleLanguage' style={caretDownStyle} />
 					: undefined
 			}
-			onRenderTitle={isLessThanSM ? () => <></> : undefined}
 			styles={dropdownStyle}
 		/>
 	)
@@ -89,39 +89,7 @@ function useDropdownStyle() {
 			dropdown: {
 				fontSize: 12,
 				border: 'none',
-				textTransform: 'capitalize',
-				selectors: {
-					':focus': {
-						'.ms-Dropdown-title': {
-							color: 'var(--bs-white)'
-						},
-						'.ms-Dropdown-caretDown': {
-							color: 'var(--bs-white)'
-						}
-					},
-					':hover': {
-						'.ms-Dropdown-title': {
-							color: 'var(--bs-white)'
-						},
-						'.ms-Dropdown-caretDown': {
-							color: 'var(--bs-white)'
-						}
-					},
-					':active': {
-						'.ms-Dropdown-title': {
-							color: 'var(--bs-white)'
-						},
-						'.ms-Dropdown-caretDown': {
-							color: 'var(--bs-white)'
-						}
-					}
-				}
-			},
-			title: {
-				backgroundColor: 'transparent',
-				color: 'var(--bs-white)',
-				border: 'none',
-				outline: 'none'
+				textTransform: 'capitalize'
 			},
 			caretDown: {
 				color: 'var(--bs-white)'

--- a/packages/webapp/src/components/ui/LanguageDropdown/index.tsx
+++ b/packages/webapp/src/components/ui/LanguageDropdown/index.tsx
@@ -36,7 +36,6 @@ export const LanguageDropdown: FC<{ className?: string }> = memo(function Langua
 			options={localeOptions}
 			selectedKey={locale}
 			role='button'
-			label={c('language')}
 			ariaLabel={c('languageDropdownAriaLabel')}
 			onChange={handleChange}
 			className={cx(className)}

--- a/packages/webapp/src/components/ui/Persona/index.module.scss
+++ b/packages/webapp/src/components/ui/Persona/index.module.scss
@@ -1,8 +1,11 @@
 .persona {
 	cursor: pointer;
+	display: flex;
+	align-items: center;
 }
 .userName {
 	overflow: hidden;
-	max-width: 20em;
+	max-width: 20rem;
 	text-overflow: ellipsis;
+	padding-right: 1rem;
 }

--- a/packages/webapp/src/components/ui/Persona/index.module.scss
+++ b/packages/webapp/src/components/ui/Persona/index.module.scss
@@ -1,3 +1,8 @@
 .persona {
 	cursor: pointer;
 }
+.userName {
+	overflow: hidden;
+	max-width: 20em;
+	text-overflow: ellipsis;
+}

--- a/packages/webapp/src/components/ui/Persona/index.tsx
+++ b/packages/webapp/src/components/ui/Persona/index.tsx
@@ -12,12 +12,14 @@ import { useTranslation } from '~hooks/useTranslation'
 import { useCurrentUser } from '~hooks/api/useCurrentUser'
 import { useNavCallback } from '~hooks/useNavCallback'
 import { ApplicationRoute } from '~types/ApplicationRoute'
+import { useWindowSize } from '~hooks/useWindowSize'
 
 export const Persona: StandardFC = memo(function Persona({ className }) {
 	const [personaMenuOpen, setPersonaMenuOpen] = useState(false)
 	const personaComponent = useRef(null)
 	const { logout } = useAuthUser()
 	const { currentUser } = useCurrentUser()
+	const { isLG } = useWindowSize()
 	const { c } = useTranslation()
 	const firstName = currentUser?.name?.first || ''
 	const onAccountClick = useNavCallback(ApplicationRoute.Account)
@@ -31,7 +33,7 @@ export const Persona: StandardFC = memo(function Persona({ className }) {
 			>
 				{/* TODO: remove stack in favor of styled div component */}
 				<div className='d-flex align-items-center justify-content-center'>
-					<div className='pr-3 me-3'>{c('personaTitle', { firstName })}</div>
+					{isLG && <div className='pr-3 me-3'>{c('personaTitle', { firstName })}</div>}
 					<>
 						<FluentPersona
 							ref={personaComponent}

--- a/packages/webapp/src/components/ui/Persona/index.tsx
+++ b/packages/webapp/src/components/ui/Persona/index.tsx
@@ -22,6 +22,7 @@ export const Persona: StandardFC = memo(function Persona({ className }) {
 	const { isLG } = useWindowSize()
 	const { c } = useTranslation()
 	const firstName = currentUser?.name?.first || ''
+	const lastName = currentUser?.name?.last || ''
 	const onAccountClick = useNavCallback(ApplicationRoute.Account)
 	const onLogoutClick = useNavCallback(ApplicationRoute.Logout)
 
@@ -34,7 +35,7 @@ export const Persona: StandardFC = memo(function Persona({ className }) {
 				{/* TODO: remove stack in favor of styled div component */}
 				<div className='d-flex align-items-center justify-content-center'>
 					{isLG && (
-						<div className={cx(style.userName, 'pr-3', 'me-3')} title={firstName}>
+						<div className={cx(style.userName, 'pr-3', 'me-3')} title={`${firstName} ${lastName}`}>
 							{firstName}
 						</div>
 					)}

--- a/packages/webapp/src/components/ui/Persona/index.tsx
+++ b/packages/webapp/src/components/ui/Persona/index.tsx
@@ -3,6 +3,7 @@
  * Licensed under the MIT license. See LICENSE file in the project.
  */
 import { ContextualMenu, Persona as FluentPersona, PersonaSize } from '@fluentui/react'
+import cx from 'classnames'
 import { memo, useRef, useState } from 'react'
 import style from './index.module.scss'
 import type { StandardFC } from '~types/StandardFC'
@@ -27,7 +28,10 @@ export const Persona: StandardFC = memo(function Persona({ className }) {
 
 	return (
 		<div className={className}>
-			<div onClick={() => setPersonaMenuOpen(true)} className={style.persona}>
+			<div
+				onClick={() => setPersonaMenuOpen(true)}
+				className={cx(style.persona, 'personaMenuContainer')}
+			>
 				{/* TODO: remove stack in favor of styled div component */}
 				<div className='d-flex align-items-center justify-content-center'>
 					{isLG && (

--- a/packages/webapp/src/components/ui/Persona/index.tsx
+++ b/packages/webapp/src/components/ui/Persona/index.tsx
@@ -33,7 +33,11 @@ export const Persona: StandardFC = memo(function Persona({ className }) {
 			>
 				{/* TODO: remove stack in favor of styled div component */}
 				<div className='d-flex align-items-center justify-content-center'>
-					{isLG && <div className='pr-3 me-3'>{c('personaTitle', { firstName })}</div>}
+					{isLG && (
+						<div className={cx(style.userName, 'pr-3', 'me-3')} title={firstName}>
+							{firstName}
+						</div>
+					)}
 					<>
 						<FluentPersona
 							ref={personaComponent}

--- a/packages/webapp/src/components/ui/Persona/index.tsx
+++ b/packages/webapp/src/components/ui/Persona/index.tsx
@@ -3,7 +3,6 @@
  * Licensed under the MIT license. See LICENSE file in the project.
  */
 import { ContextualMenu, Persona as FluentPersona, PersonaSize } from '@fluentui/react'
-import cx from 'classnames'
 import { memo, useRef, useState } from 'react'
 import style from './index.module.scss'
 import type { StandardFC } from '~types/StandardFC'
@@ -28,14 +27,11 @@ export const Persona: StandardFC = memo(function Persona({ className }) {
 
 	return (
 		<div className={className}>
-			<div
-				onClick={() => setPersonaMenuOpen(true)}
-				className={cx(style.persona, 'd-flex align-items-center', 'personaMenuContainer')}
-			>
+			<div onClick={() => setPersonaMenuOpen(true)} className={style.persona}>
 				{/* TODO: remove stack in favor of styled div component */}
 				<div className='d-flex align-items-center justify-content-center'>
 					{isLG && (
-						<div className={cx(style.userName, 'pr-3', 'me-3')} title={`${firstName} ${lastName}`}>
+						<div className={style.userName} title={`${firstName} ${lastName}`}>
 							{firstName}
 						</div>
 					)}

--- a/packages/webapp/src/components/ui/PersonalNav/index.tsx
+++ b/packages/webapp/src/components/ui/PersonalNav/index.tsx
@@ -9,13 +9,13 @@ import type { FC } from 'react'
 import { memo } from 'react'
 
 export const PersonalNav: FC = memo(function PersonalNav() {
-	const { isLG } = useWindowSize()
+	const { isLessThanMD } = useWindowSize()
 
 	return (
 		<div className='d-flex align-items-center'>
 			<Persona className='me-3 me-lg-0' />
 
-			{!isLG && <MobileMenu />}
+			{isLessThanMD && <MobileMenu />}
 		</div>
 	)
 })

--- a/packages/webapp/src/components/ui/TopNav/index.module.scss
+++ b/packages/webapp/src/components/ui/TopNav/index.module.scss
@@ -12,9 +12,7 @@
 	& > a {
 		color: color('text-light') !important;
 		font-weight: 600;
-		&:not(:first-child) {
-			margin-left: 3rem;
-		}
+		margin-right: 3rem;
 
 		&[class*='nav-active']::before {
 			content: '';

--- a/packages/webapp/src/components/ui/TopNav/index.module.scss
+++ b/packages/webapp/src/components/ui/TopNav/index.module.scss
@@ -8,8 +8,8 @@
 .topNav {
 	& > a {
 		font-weight: 600;
-		&:not(:last-child) {
-			margin-right: space(6);
+		&:not(:first-child) {
+			margin-left: 3rem;
 		}
 	}
 }

--- a/packages/webapp/src/locales/en-US/account.json
+++ b/packages/webapp/src/locales/en-US/account.json
@@ -14,7 +14,7 @@
       "totalEngagementCompleted": "Total Requests Completed",
       "_totalEngagementCompleted.comment": "Total Requests Completed field label",
       "profile": "Profile",
-      "_settings.profile": "sub header title text for profile",
+      "_profile.comment": "sub header title text for profile",
       "settings": "Settings",
       "_settings.comment": "sub header title text for settings"
     },
@@ -62,7 +62,7 @@
       "confirmPasswordPlaceholder": "Confirm new password",
       "_confirmPasswordPlaceholder.comment": "Placeholder for confirm new password",
       "language": "Language",
-      "language.comment": "label for the language dropdown in user settings"
+      "_language.comment": "label for the language dropdown in user settings"
     },
     "buttons": {
       "save": "Save",

--- a/packages/webapp/src/locales/en-US/account.json
+++ b/packages/webapp/src/locales/en-US/account.json
@@ -3,8 +3,8 @@
   "_pageTitle.comment": "Page title displayed in the browser tab",
   "account": {
     "header": {
-      "title": "My Profile",
-      "_title.comment": "Header title text",
+      "title": "My Account",
+      "_title.comment": "Header title text for account",
       "userName": "Username",
       "_userName.comment": "Username field label",
       "userSince": "User since",
@@ -12,7 +12,11 @@
       "numOfAssignedEngagements": "# of Currently Assigned Requests",
       "_numOfAssignedEngagements.comment": "# of Currently Assigned Requests for Assistance field label",
       "totalEngagementCompleted": "Total Requests Completed",
-      "_totalEngagementCompleted.comment": "Total Requests Completed field label"
+      "_totalEngagementCompleted.comment": "Total Requests Completed field label",
+      "profile": "Profile",
+      "_settings.profile": "sub header title text for profile",
+      "settings": "Settings",
+      "_settings.comment": "sub header title text for settings"
     },
     "fields": {
       "nameInfo": "Name",
@@ -56,7 +60,9 @@
       "newPasswordPlaceholder": "New password",
       "_newPasswordPlaceholder.comment": "Placeholder for new password",
       "confirmPasswordPlaceholder": "Confirm new password",
-      "_confirmPasswordPlaceholder.comment": "Placeholder for confirm new password"
+      "_confirmPasswordPlaceholder.comment": "Placeholder for confirm new password",
+      "language": "Language",
+      "language.comment": "label for the language dropdown in user settings"
     },
     "buttons": {
       "save": "Save",

--- a/packages/webapp/src/locales/en-US/common.json
+++ b/packages/webapp/src/locales/en-US/common.json
@@ -23,7 +23,7 @@
     "reportingText": "Reporting",
     "_reportingText.comment": "Top navigation item for Reporting page"
   },
-  "personaTitle": "Hello, [[firstName]]",
+  "personaTitle": "[[firstName]]",
   "_personaTitle.comment": "Hello string to greet logged-in user. {Placeholder = [,firstName,]}",
   "personaMenu": {
     "accountText": "Account",
@@ -85,8 +85,10 @@
     "datePickerAriaLabel": "Select a date",
     "_datePickerAriaLabel.comment": "Default aria label for date picker components"
   },
+  "language": "Language",
+  "language.comment": "label for the language dropdown in user settings",
   "languageDropdownAriaLabel": "Language dropdown, use arrow keys if using tab navigation to select a language",
-  "_languageDropdownAriaLabel.comment": "Aria label for language select dropdown in action bar on top of the page",
+  "_languageDropdownAriaLabel.comment": "Aria label for language select dropdown in user settings",
   "shortString": {
     "more": "...more",
     "_more.comment": "Show more label for long text",

--- a/packages/webapp/src/locales/en-US/common.json
+++ b/packages/webapp/src/locales/en-US/common.json
@@ -85,8 +85,6 @@
     "datePickerAriaLabel": "Select a date",
     "_datePickerAriaLabel.comment": "Default aria label for date picker components"
   },
-  "language": "Language",
-  "language.comment": "label for the language dropdown in user settings",
   "languageDropdownAriaLabel": "Language dropdown, use arrow keys if using tab navigation to select a language",
   "_languageDropdownAriaLabel.comment": "Aria label for language select dropdown in user settings",
   "shortString": {


### PR DESCRIPTION
**What** 
- Updated various acceptance test files related to the Header and ProfilePage components.
- Updated the ProfilePage form to include the LanguageDropdown and reworked the page to match the proposed new layout
- Updated the LanguageDropdown's style and responsive behavior per it's new location to display correctly there.
- Updated the Persona, PersonaNav and TopNav components layout and style to handle the changes to responsiveness as well as to catch missing expect behavior like cursors for actionable items.
- Updated the locale files to account for new and updated strings that were needed for all of this. 

**Why**
- Provides a much more responsive header bar that keeps more of the important items visible in narrower viewports.
- ProfilePage becomes more like like a general account settings page.

**How**
- Per the issue's design, changed some of the styling and breakpoints such that it would keep the desired header menu elements on screen longer, as well accounting for edge things like longer names that could create an issue with the breakpoint changes by adding some CSS rules to avoid those problems.
- Similarly, reworked the layout of the account/profile view into the dual column design proposed in the issue design by moving various existing sections of that layout to match and handle the addition of the language selection. 

**Testing**
- Moved language related testing from the header to the profile.
- Cut language tests that were over-zealous (we just need to see the element is on the profile page.)
- Did manual testing of the breakpoint changes during development to ensure that they triggered as expect as the viewport changed/shrunk.

**Screenshots**
Before Mobile:
- ![Screen Shot 2022-04-12 at 2 51 35 PM](https://user-images.githubusercontent.com/51097558/163060844-462d5277-1175-409d-a175-83b3e205ec91.png)

After Mobile:
- ![Screen Shot 2022-04-12 at 2 50 55 PM](https://user-images.githubusercontent.com/51097558/163060749-c5155f10-690e-4970-8e8b-ca418cfef09d.png)

Before Medium/Tablet:
- ![Screen Shot 2022-04-12 at 2 44 25 PM](https://user-images.githubusercontent.com/51097558/163060970-6f0b3cff-3703-404f-bb20-23995d7d2746.png)

After Medium/Tablet:
- ![Screen Shot 2022-04-12 at 2 41 09 PM](https://user-images.githubusercontent.com/51097558/163061054-69fec4bf-af70-417f-a78a-14c104407cb9.png)

Before Full:
- ![Screen Shot 2022-04-12 at 2 44 44 PM](https://user-images.githubusercontent.com/51097558/163061710-c06e6412-53db-451d-b280-2a13fe1e4d20.png)

After Full:
- ![Screen Shot 2022-04-12 at 2 41 36 PM](https://user-images.githubusercontent.com/51097558/163061649-c4737092-e614-46cb-b3dc-6006a688a464.png)


**Anything else**
Reworking the profile was a strong reminder we should consider specifically calling out the work to start doing two things: 
1. Start deprecating react-bootstrap components like `Row` and `Col` to say nothing of the myriad bootstrap classes in favor of FluentUI React elements like `Stack` (https://developer.microsoft.com/en-us/fluentui#/controls/web/stack) such that we don't have as many library dependencies so dev is less challenging as we can stick to one set of documentation.
2. While handling the above, we also have some pretty similar forms for Admin/User accounts and Clients amongst other code duplication, so there's a strong reuse opportunity here to clean that up while streamlining dependencies.


Closes #314 