### PR TITLE
fix client tags not being filterable

### DIFF
--- a/packages/webapp/src/components/lists/ReportList/reports/RequestReport/useRequestReportFilters.ts
+++ b/packages/webapp/src/components/lists/ReportList/reports/RequestReport/useRequestReportFilters.ts
@@ -8,7 +8,7 @@ import type { IFieldFilter } from '../../types'
 function buildReportFilters(): IFieldFilter[] {
 	const clientFilters = [
 		'name',
-		'clientTags',
+		'tags',
 		'gender',
 		'race',
 		'ethnicity',

--- a/packages/webapp/src/components/lists/ReportList/reports/ServiceReport/index.tsx
+++ b/packages/webapp/src/components/lists/ReportList/reports/ServiceReport/index.tsx
@@ -18,7 +18,7 @@ import { useServiceReportFilters } from './useServiceReportFilters'
 import { useEditState } from './useEditState'
 import { useDeleteState } from './useDeleteState'
 
-export const ServiceReport: FC<CommonReportProps> = memo(function ClientReport({
+export const ServiceReport: FC<CommonReportProps> = memo(function ServiceReport({
 	data,
 	service,
 	filterColumns,

--- a/packages/webapp/src/components/lists/ReportList/reports/ServiceReport/useServiceReportFilters.ts
+++ b/packages/webapp/src/components/lists/ReportList/reports/ServiceReport/useServiceReportFilters.ts
@@ -46,7 +46,7 @@ function buildServiceFilters(service: Service): IFieldFilter[] {
 				'county',
 				'state',
 				'zip',
-				'clientTags'
+				'tags'
 		  ].map((filter) => ({
 				id: filter,
 				name: filter,


### PR DESCRIPTION
Fixes: #495 

**What** 
 - Fixes an issue that causes client tags to not be filterable 

**Why**
 - it seemed like an incorrect key value was causing this issue
 
**How**
 - rename `clientTags` => `tags`

**Testing**
 - navigate to either the requests or service table
 - filter by client tags
