### PR TITLE
Add Help Menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ deploy.zip
 # Dev Environments
 .env*
 mangod.conf
+launch.json
 
 # LogFiles
 packages/webapp/test-output.html

--- a/packages/webapp/src/components/ui/ActionBar/index.tsx
+++ b/packages/webapp/src/components/ui/ActionBar/index.tsx
@@ -13,6 +13,7 @@ import { ContainerRowColumn as CRC } from '~ui/CRC'
 import { PersonalNav } from '~ui/PersonalNav'
 import { TopNav } from '~ui/TopNav'
 import { Notifications } from '~ui/Notifications'
+import { HelpMenu } from '../HelpMenu'
 import { useTranslation } from '~hooks/useTranslation'
 
 export interface ActionBarProps {
@@ -50,6 +51,7 @@ export const ActionBar: StandardFC<ActionBarProps> = memo(function ActionBar({ t
 					</div>
 					<div className='d-flex justify-content-between align-items-center'>
 						<Notifications />
+						<HelpMenu />
 						<PersonalNav />
 					</div>
 				</div>

--- a/packages/webapp/src/components/ui/HelpMenu/index.module.scss
+++ b/packages/webapp/src/components/ui/HelpMenu/index.module.scss
@@ -1,0 +1,6 @@
+.helpMenu {
+	padding-right: 10px;
+	padding-left: 10px;
+	cursor: pointer;
+	letter-spacing: 0.09px;
+}

--- a/packages/webapp/src/components/ui/HelpMenu/index.tsx
+++ b/packages/webapp/src/components/ui/HelpMenu/index.tsx
@@ -1,0 +1,54 @@
+/*!
+ * Copyright (c) Microsoft. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project.
+ */
+import { ContextualMenu, ContextualMenuItemType } from '@fluentui/react/lib/ContextualMenu'
+import * as React from 'react'
+import cx from 'classnames'
+import { useState } from 'react'
+import styles from './index.module.scss'
+import { FontIcon } from '@fluentui/react/lib/Icon'
+import { useTranslation } from '~hooks/useTranslation'
+import { mergeStyles } from '@fluentui/react/lib/Styling'
+
+export const HelpMenu: React.FunctionComponent = () => {
+	const linkRef = React.useRef(null)
+	const { c } = useTranslation()
+	const [personaMenuOpen, setPersonaMenuOpen] = useState(false)
+	return (
+		<div onClick={() => setPersonaMenuOpen(true)}>
+			<div className={cx(styles.helpMenu)} ref={linkRef}>
+				<FontIcon
+					aria-label='Help'
+					iconName='Help'
+					role='img'
+					className={mergeStyles({ fontSize: '28px' })}
+				/>
+			</div>
+			<ContextualMenu
+				items={[
+					{
+						key: 'helpArticles',
+						text: c('helpMenu.helpArticlesLabel'),
+						href: 'http://help.healthycommunityhub.com',
+						target: '_blank'
+					},
+					{
+						key: 'divider_1',
+						itemType: ContextualMenuItemType.Divider
+					},
+					{
+						key: 'contactSupport',
+						text: c('helpMenu.contactSupportLabel'),
+						href: 'mailto:help@healthycommunityhub.com',
+						target: '_blank'
+					}
+				]}
+				hidden={!personaMenuOpen}
+				target={linkRef}
+				onItemClick={() => setPersonaMenuOpen(false)}
+				onDismiss={() => setPersonaMenuOpen(false)}
+			/>
+		</div>
+	)
+}

--- a/packages/webapp/src/locales/en-US/common.json
+++ b/packages/webapp/src/locales/en-US/common.json
@@ -23,6 +23,10 @@
     "reportingText": "Reporting",
     "_reportingText.comment": "Top navigation item for Reporting page"
   },
+  "helpMenu": {
+    "helpArticlesLabel": "Help Articles",
+    "contactSupportLabel": "Contact Support"
+  },
   "personaTitle": "[[firstName]]",
   "_personaTitle.comment": "Hello string to greet logged-in user. {Placeholder = [,firstName,]}",
   "personaMenu": {


### PR DESCRIPTION
**What** 
Ticket: https://github.com/microsoft/community-organization-operations-suite/issues/483
This added a help dropdown menu to make it easier for users to send a request for help email and a link to the docs page

**Why**
UI requested change

**How**
 Used the Fluent UI Contextual Menu component to add the drop down
 
**Testing**
There are 2 options to added to the dropdown
- Send email
- Open Help Page

**Screenshots**
<img width="318" alt="image" src="https://user-images.githubusercontent.com/95376249/163431449-c0e21356-52b5-454f-a7f2-7e487f265a4a.png">

**Anything else**
 - I was thinking that maybe single component should be created to make the drop down more reusable. Unless there are more Contextual Menu use cases, I don't think it would be useful.
