### PR TITLE
Clear multi choice filter properly when clicking clear filter button

### DIFF
--- a/packages/webapp/src/components/lists/ReportList/reports/ClientReport/useClientReportColumns.tsx
+++ b/packages/webapp/src/components/lists/ReportList/reports/ClientReport/useClientReportColumns.tsx
@@ -3,7 +3,6 @@
  * Licensed under the MIT license. See LICENSE file in the project.
  */
 import type { Contact } from '@cbosuite/schema/dist/client-types'
-import type { CustomOption } from '~components/ui/CustomOptionsFilter'
 import { useMemo } from 'react'
 import { CustomDateRangeFilter } from '~components/ui/CustomDateRangeFilter'
 import { CustomOptionsFilter } from '~components/ui/CustomOptionsFilter'
@@ -21,7 +20,7 @@ import { ContactName, getContactTitle } from '~components/lists/ContactList/Cont
 import { sortByAlphanumeric, sortByDate, sortByTags } from '~utils/sorting'
 
 export function useClientReportColumns(
-	filterColumns: (columnId: string, option: CustomOption) => void,
+	filterColumns: (columnId: string, value: string[]) => void,
 	filterColumnTextValue: (key: string, value: string) => void,
 	filterRangedValues: (key: string, value: string[]) => void,
 	getDemographicValue: (demographicKey: string, contact: Contact) => string,
@@ -101,7 +100,7 @@ export function useClientReportColumns(
 									text: tag.label
 								}
 							})}
-							onFilterChanged={(option) => filterColumns(key, option)}
+							onFilterChanged={(value) => filterColumns(key, value)}
 							onTrackEvent={onTrackEvent}
 						/>
 					)
@@ -132,7 +131,7 @@ export function useClientReportColumns(
 									text: t(`demographics.${key}.options.${o.key}`)
 								}
 							})}
-							onFilterChanged={(option) => filterColumns(key, option)}
+							onFilterChanged={(value) => filterColumns(key, value)}
 							onTrackEvent={onTrackEvent}
 						/>
 					)
@@ -213,7 +212,7 @@ export function useClientReportColumns(
 								key: o.key,
 								text: t(`demographics.${key}.options.${o.key}`)
 							}))}
-							onFilterChanged={(option) => filterColumns(key, option)}
+							onFilterChanged={(value) => filterColumns(key, value)}
 							onTrackEvent={onTrackEvent}
 						/>
 					)
@@ -242,7 +241,7 @@ export function useClientReportColumns(
 								key: o.key,
 								text: t(`demographics.${key}.options.${o.key}`)
 							}))}
-							onFilterChanged={(option) => filterColumns(key, option)}
+							onFilterChanged={(value) => filterColumns(key, value)}
 							onTrackEvent={onTrackEvent}
 						/>
 					)
@@ -271,7 +270,7 @@ export function useClientReportColumns(
 								key: o.key,
 								text: t(`demographics.${key}.options.${o.key}`)
 							}))}
-							onFilterChanged={(option) => filterColumns(key, option)}
+							onFilterChanged={(value) => filterColumns(key, value)}
 							onTrackEvent={onTrackEvent}
 						/>
 					)
@@ -300,7 +299,7 @@ export function useClientReportColumns(
 								key: o.key,
 								text: t(`demographics.${key}.options.${o.key}`)
 							}))}
-							onFilterChanged={(option) => filterColumns(key, option)}
+							onFilterChanged={(value) => filterColumns(key, value)}
 							onTrackEvent={onTrackEvent}
 						/>
 					)

--- a/packages/webapp/src/components/lists/ReportList/reports/RequestReport/useRequestReportColumns/index.tsx
+++ b/packages/webapp/src/components/lists/ReportList/reports/RequestReport/useRequestReportColumns/index.tsx
@@ -5,12 +5,11 @@
 import type { Contact } from '@cbosuite/schema/dist/client-types'
 import { useMemo } from 'react'
 import type { IPaginatedTableColumn } from '~components/ui/PaginatedTable/types'
-import type { IDropdownOption } from '@fluentui/react'
 import { useRequestFieldColumns } from './useRequestFieldColumns'
 import { useContactFormColumns } from './useContactFormColumns'
 
 export function useRequestReportColumns(
-	filterColumns: (columnId: string, option: IDropdownOption) => void,
+	filterColumns: (columnId: string, value: string[]) => void,
 	filterColumnTextValue: (key: string, value: string) => void,
 	filterRangedValues: (key: string, value: string[]) => void,
 	getDemographicValue: (demographicKey: string, contact: Contact) => string,

--- a/packages/webapp/src/components/lists/ReportList/reports/RequestReport/useRequestReportColumns/useContactFormColumns.tsx
+++ b/packages/webapp/src/components/lists/ReportList/reports/RequestReport/useRequestReportColumns/useContactFormColumns.tsx
@@ -9,7 +9,6 @@ import { CustomTextFieldFilter } from '~components/ui/CustomTextFieldFilter'
 import { CLIENT_DEMOGRAPHICS } from '~constants'
 import { Namespace, useTranslation } from '~hooks/useTranslation'
 import styles from '../../../index.module.scss'
-import type { CustomOption } from '~components/ui/CustomOptionsFilter'
 import { CustomDateRangeFilter } from '~components/ui/CustomDateRangeFilter'
 import { TagBadgeList } from '~ui/TagBadgeList'
 import { useLocale } from '~hooks/useLocale'
@@ -19,7 +18,7 @@ import { useGetValue } from '~components/lists/ReportList/hooks'
 import { sortByAlphanumeric, sortByDate, sortByTags } from '~utils/sorting'
 
 export function useContactFormColumns(
-	filterColumns: (columnId: string, option: CustomOption) => void,
+	filterColumns: (columnId: string, value: string[]) => void,
 	filterColumnTextValue: (key: string, value: string) => void,
 	filterRangedValues: (key: string, value: string[]) => void,
 	getDemographicValue: (demographicKey: string, contact: Contact) => string,
@@ -99,7 +98,7 @@ export function useContactFormColumns(
 									text: tag.label
 								}
 							})}
-							onFilterChanged={(option) => filterColumns(key, option)}
+							onFilterChanged={(value) => filterColumns(key, value)}
 							onTrackEvent={onTrackEvent}
 						/>
 					)
@@ -128,7 +127,7 @@ export function useContactFormColumns(
 								key: o.key,
 								text: t(`demographics.${key}.options.${o.key}`)
 							}))}
-							onFilterChanged={(option) => filterColumns(key, option)}
+							onFilterChanged={(value) => filterColumns(key, value)}
 							onTrackEvent={onTrackEvent}
 						/>
 					)
@@ -211,7 +210,7 @@ export function useContactFormColumns(
 								key: o.key,
 								text: t(`demographics.${key}.options.${o.key}`)
 							}))}
-							onFilterChanged={(option) => filterColumns(key, option)}
+							onFilterChanged={(value) => filterColumns(key, value)}
 							onTrackEvent={onTrackEvent}
 						/>
 					)
@@ -240,7 +239,7 @@ export function useContactFormColumns(
 								key: o.key,
 								text: t(`demographics.${key}.options.${o.key}`)
 							}))}
-							onFilterChanged={(option) => filterColumns(key, option)}
+							onFilterChanged={(value) => filterColumns(key, value)}
 							onTrackEvent={onTrackEvent}
 						/>
 					)
@@ -269,7 +268,7 @@ export function useContactFormColumns(
 								key: o.key,
 								text: t(`demographics.${key}.options.${o.key}`)
 							}))}
-							onFilterChanged={(option) => filterColumns(key, option)}
+							onFilterChanged={(value) => filterColumns(key, value)}
 							onTrackEvent={onTrackEvent}
 						/>
 					)
@@ -298,7 +297,7 @@ export function useContactFormColumns(
 								key: o.key,
 								text: t(`demographics.${key}.options.${o.key}`)
 							}))}
-							onFilterChanged={(option) => filterColumns(key, option)}
+							onFilterChanged={(value) => filterColumns(key, value)}
 							onTrackEvent={onTrackEvent}
 						/>
 					)

--- a/packages/webapp/src/components/lists/ReportList/reports/RequestReport/useRequestReportColumns/useRequestFieldColumns.tsx
+++ b/packages/webapp/src/components/lists/ReportList/reports/RequestReport/useRequestReportColumns/useRequestFieldColumns.tsx
@@ -8,7 +8,6 @@ import { CustomTextFieldFilter } from '~components/ui/CustomTextFieldFilter'
 import type { IPaginatedTableColumn } from '~components/ui/PaginatedTable/types'
 import styles from '../../../index.module.scss'
 import { CustomDateRangeFilter } from '~components/ui/CustomDateRangeFilter'
-import type { CustomOption } from '~components/ui/CustomOptionsFilter'
 import { useLocale } from '~hooks/useLocale'
 import { Namespace, useTranslation } from '~hooks/useTranslation'
 import { CustomOptionsFilter } from '~components/ui/CustomOptionsFilter'
@@ -21,7 +20,7 @@ import { sortByAlphanumeric, sortByDate, sortByTags } from '~utils/sorting'
 import { truncate } from 'lodash'
 
 export function useRequestFieldColumns(
-	filterColumns: (columnId: string, option: CustomOption) => void,
+	filterColumns: (columnId: string, value: string[]) => void,
 	filterColumnTextValue: (key: string, value: string) => void,
 	filterRangedValues: (key: string, value: string[]) => void,
 	hiddenFields: Record<string, boolean>,
@@ -101,7 +100,7 @@ export function useRequestFieldColumns(
 									text: tag.label
 								}
 							})}
-							onFilterChanged={(option) => filterColumns(key, option)}
+							onFilterChanged={(value) => filterColumns(key, value)}
 							onTrackEvent={onTrackEvent}
 						/>
 					)
@@ -210,7 +209,7 @@ export function useRequestFieldColumns(
 							filterLabel={name}
 							placeholder={name}
 							options={statusList}
-							onFilterChanged={(option) => filterColumns(key, option)}
+							onFilterChanged={(value) => filterColumns(key, value)}
 							onTrackEvent={onTrackEvent}
 						/>
 					)

--- a/packages/webapp/src/components/lists/ReportList/reports/ServiceReport/useServiceReportColumns/index.tsx
+++ b/packages/webapp/src/components/lists/ReportList/reports/ServiceReport/useServiceReportColumns/index.tsx
@@ -5,7 +5,6 @@
 import type { Contact, Service, ServiceAnswer } from '@cbosuite/schema/dist/client-types'
 import { useMemo } from 'react'
 import type { IPaginatedTableColumn } from '~components/ui/PaginatedTable/types'
-import type { IDropdownOption } from '@fluentui/react'
 import { empty } from '~utils/noop'
 import { useActionColumns } from './useActionColumns'
 import { useServiceFieldColumns } from './useServiceFieldColumns'
@@ -14,7 +13,7 @@ import { useContactFormColumns } from './useContactFormColumns'
 export function useServiceReportColumns(
 	service: Service,
 	data: unknown[],
-	filterColumns: (columnId: string, option: IDropdownOption) => void,
+	filterColumns: (columnId: string, value: string[]) => void,
 	filterColumnTextValue: (key: string, value: string) => void,
 	filterRangedValues: (key: string, value: string[]) => void,
 	getDemographicValue: (demographicKey: string, contact: Contact) => string,

--- a/packages/webapp/src/components/lists/ReportList/reports/ServiceReport/useServiceReportColumns/useContactFormColumns.tsx
+++ b/packages/webapp/src/components/lists/ReportList/reports/ServiceReport/useServiceReportColumns/useContactFormColumns.tsx
@@ -4,12 +4,11 @@
  */
 import type { Contact } from '@cbosuite/schema/dist/client-types'
 import { useMemo } from 'react'
-import type { IDropdownOption } from '@fluentui/react'
 import { useContactFormColumns as useContactFormColumnsHelper } from '../../RequestReport/useRequestReportColumns/useContactFormColumns'
 
 export function useContactFormColumns(
 	enabled: boolean,
-	filterColumns: (columnId: string, option: IDropdownOption) => void,
+	filterColumns: (columnId: string, value: string[]) => void,
 	filterColumnTextValue: (key: string, value: string) => void,
 	filterRangedValues: (key: string, value: string[]) => void,
 	getDemographicValue: (demographicKey: string, contact: Contact) => string,

--- a/packages/webapp/src/components/lists/ReportList/reports/ServiceReport/useServiceReportColumns/useServiceFieldColumns.tsx
+++ b/packages/webapp/src/components/lists/ReportList/reports/ServiceReport/useServiceReportColumns/useServiceFieldColumns.tsx
@@ -10,7 +10,6 @@ import { CustomTextFieldFilter } from '~components/ui/CustomTextFieldFilter'
 import type { IPaginatedTableColumn } from '~components/ui/PaginatedTable/types'
 import styles from '../../../index.module.scss'
 import { CustomDateRangeFilter } from '~components/ui/CustomDateRangeFilter'
-import type { CustomOption } from '~components/ui/CustomOptionsFilter'
 import { CustomNumberRangeFilter } from '~components/ui/CustomNumberRangeFilter'
 import { ShortString } from '~components/ui/ShortString'
 import { useLocale } from '~hooks/useLocale'
@@ -32,7 +31,7 @@ function shorten(value: string): string {
 export function useServiceFieldColumns(
 	data: unknown[],
 	fields: ServiceField[],
-	filterColumns: (columnId: string, option: CustomOption) => void,
+	filterColumns: (columnId: string, value: string[]) => void,
 	filterColumnTextValue: (key: string, value: string) => void,
 	filterRangedValues: (key: string, value: string[]) => void,
 	hiddenFields: Record<string, boolean>,
@@ -59,7 +58,7 @@ export function useServiceFieldColumns(
 									filterLabel={name}
 									placeholder={name}
 									options={field.inputs.map((value) => ({ key: value.id, text: value.label }))}
-									onFilterChanged={(option) => filterColumns(key, option)}
+									onFilterChanged={(value) => filterColumns(key, value)}
 									onTrackEvent={onTrackEvent}
 								/>
 							)

--- a/packages/webapp/src/components/lists/ReportList/reports/types.ts
+++ b/packages/webapp/src/components/lists/ReportList/reports/types.ts
@@ -4,7 +4,6 @@
  */
 
 import type { Contact, Service } from '@cbosuite/schema/dist/client-types'
-import type { IDropdownOption } from '@fluentui/react'
 import type { CsvField, IFieldFilter } from '../types'
 
 export type FilterHelper = (data: unknown[], filter: IFieldFilter, utils: any) => unknown[]
@@ -14,7 +13,7 @@ export interface CommonReportProps {
 	fieldFilters?: IFieldFilter[]
 	setFieldFilters: (filters: IFieldFilter[]) => void
 	hiddenFields: Record<string, boolean>
-	filterColumns: (columnId: string, option: IDropdownOption) => void
+	filterColumns: (columnId: string, value: string[]) => void
 	filterColumnTextValue: (key: string, value: string) => void
 	filterRangedValues: (key: string, value: string[]) => void
 	getDemographicValue: (demographicKey: string, contact: Contact) => string

--- a/packages/webapp/src/components/lists/ReportList/useFilteredData.ts
+++ b/packages/webapp/src/components/lists/ReportList/useFilteredData.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT license. See LICENSE file in the project.
  */
 import type { Contact } from '@cbosuite/schema/dist/client-types'
-import type { IDropdownOption } from '@fluentui/react'
 import { useCallback, useEffect, useState } from 'react'
 import { useRecoilState } from 'recoil'
 import { Namespace, useTranslation } from '~hooks/useTranslation'

--- a/packages/webapp/src/components/lists/ReportList/useFilteredData.ts
+++ b/packages/webapp/src/components/lists/ReportList/useFilteredData.ts
@@ -74,25 +74,11 @@ function useFilterUtilities(
 	setReportHeaderFilters: (filters: Array<IFieldFilter>) => void
 ) {
 	const { t } = useTranslation(Namespace.Reporting, Namespace.Clients, Namespace.Services)
-	const filterColumns = (columnId: string, option: IDropdownOption) => {
+	const filterColumns = (columnId: string, value: string[]) => {
 		const fieldIndex = filters.findIndex((f) => f.id === columnId)
-		const filter = filters.find((f) => f.id === columnId)
-		const key = option.key as string
-		const value = filter?.value ? [...(filter?.value as string[])] : []
-
-		if (option.selected) {
-			if (!value.includes(key)) {
-				value.push(key)
-			}
-		} else {
-			const optionIndex = value.indexOf(key)
-			if (optionIndex > -1) {
-				value.splice(optionIndex, 1)
-			}
-		}
-
+		const oldFilter = filters[fieldIndex]
 		const newFilters = [...filters]
-		newFilters[fieldIndex] = { ...filter, value }
+		newFilters[fieldIndex] = { ...oldFilter, value }
 		setReportHeaderFilters(newFilters)
 	}
 

--- a/packages/webapp/src/components/lists/TagsList/columns.tsx
+++ b/packages/webapp/src/components/lists/TagsList/columns.tsx
@@ -13,13 +13,11 @@ import { ShortString } from '~ui/ShortString'
 import { Namespace, useTranslation } from '~hooks/useTranslation'
 import { MobileCard } from './MobileCard'
 import { CustomOptionsFilter } from '~components/ui/CustomOptionsFilter'
-import type { CustomOption } from '~components/ui/CustomOptionsFilter'
 import { TAG_CATEGORIES } from '~constants'
 
 export function usePageColumns(
 	actions: IMultiActionButtons<Tag>[],
-	filterListByCategory?: (filterOption: CustomOption) => void,
-	clearFilterByCategory?: () => void
+	filterListByCategory?: (value: string[]) => void
 ): IPaginatedListColumn[] {
 	const { t, c } = useTranslation(Namespace.Tags)
 	return useMemo(
@@ -60,8 +58,7 @@ export function usePageColumns(
 									text: c(`tagCategory.${category}`)
 								}
 							})}
-							onFilterChanged={(option) => filterListByCategory(option)}
-							onClearFilter={clearFilterByCategory}
+							onFilterChanged={(value) => filterListByCategory(value)}
 						/>
 					)
 				}
@@ -104,7 +101,7 @@ export function usePageColumns(
 				}
 			}
 		],
-		[actions, t, c, filterListByCategory, clearFilterByCategory]
+		[actions, t, c, filterListByCategory]
 	)
 }
 

--- a/packages/webapp/src/components/lists/TagsList/index.tsx
+++ b/packages/webapp/src/components/lists/TagsList/index.tsx
@@ -16,7 +16,6 @@ import { AddTagForm } from '~forms/AddTagForm'
 import { useWindowSize } from '~hooks/useWindowSize'
 import { EditTagForm } from '~forms/EditTagForm'
 import { Namespace, useTranslation } from '~hooks/useTranslation'
-import type { CustomOption } from '~components/ui/CustomOptionsFilter'
 import { trackEvent, wrap } from '~utils/appinsights'
 import { cleanForSearch } from '~utils/sorting'
 import { useMobileColumns, usePageColumns } from './columns'
@@ -67,20 +66,6 @@ export const TagsList: StandardFC<TagsListProps> = wrap(function TagsList({ titl
 	}, [debounceTrackFn])
 	// -- end Telemetry
 
-	const filterList = function (filterOption: CustomOption) {
-		const categories = new Set(selectedCategories)
-		if (filterOption.selected) {
-			categories.add(filterOption.key)
-		} else {
-			categories.delete(filterOption.key)
-		}
-		setSelectedCategories(Array.from(categories))
-	}
-
-	const clearFilter = function () {
-		setSelectedCategories([])
-	}
-
 	const searchList = function (value: string) {
 		setSearchString(value)
 		debounceTrackFn()
@@ -106,7 +91,7 @@ export const TagsList: StandardFC<TagsListProps> = wrap(function TagsList({ titl
 	]
 
 	// Columns to be displayed
-	const pageColumns = usePageColumns(actions, filterList, clearFilter)
+	const pageColumns = usePageColumns(actions, setSelectedCategories)
 	const mobileColumns = useMobileColumns(actions, onTagClick)
 
 	// List of tags displayed

--- a/packages/webapp/src/components/ui/CustomOptionsFilter/index.tsx
+++ b/packages/webapp/src/components/ui/CustomOptionsFilter/index.tsx
@@ -14,10 +14,9 @@ import { truncate } from 'lodash'
 import cx from 'classnames'
 import { Namespace, useTranslation } from '~hooks/useTranslation'
 
-export type CustomOption = {
+type CustomOption = {
 	key: string
 	text: string
-	selected?: boolean
 }
 
 interface CustomOptionsFilterProps {
@@ -25,8 +24,7 @@ interface CustomOptionsFilterProps {
 	options: CustomOption[]
 	placeholder?: string
 	defaultSelectedKeys?: string[]
-	onFilterChanged?: (option: CustomOption) => void
-	onClearFilter?: () => void
+	onFilterChanged?: (selection: string[]) => void
 	onTrackEvent?: (name: string) => void
 }
 
@@ -37,13 +35,12 @@ export const CustomOptionsFilter: StandardFC<CustomOptionsFilterProps> = wrap(
 		options,
 		defaultSelectedKeys,
 		onFilterChanged = noop,
-		onClearFilter = noop,
 		onTrackEvent = noop
 	}) {
 		const { t } = useTranslation(Namespace.Reporting)
 		const buttonId = useId('filter-callout-button')
 		const [showCallout, { toggle: toggleShowCallout }] = useBoolean(false)
-		const [selected, setSelected] = useState([])
+		const [selected, setSelected] = useState<string[]>([])
 
 		useEffect(() => {
 			if (defaultSelectedKeys) {
@@ -68,16 +65,17 @@ export const CustomOptionsFilter: StandardFC<CustomOptionsFilterProps> = wrap(
 
 			onTrackEvent('Filter Applied')
 			setSelected(_selected)
-			onFilterChanged({ selected: isChecked, ...option })
+			onFilterChanged(_selected)
 		}
 
 		const handleClearAll = function () {
 			setSelected([])
-			onClearFilter()
+			onFilterChanged([])
 		}
 
 		const title = truncate(placeholder)
 		const iconClassname = selected.length > 0 ? styles.iconActive : styles.icon
+
 		const checkboxes = options?.map((option) => {
 			return (
 				<Checkbox


### PR DESCRIPTION
**What** 
 - Fixes #522 
 - Changed multi option filter value from a single option object to an array of string representing selected values
 
**Why**
 - Taking a single option object for a filter value for multi option column makes filtering logic more complex. Passing an array of values make it more declarative and simplifies some of the logic.

**Testing**
 - Test filtering and clearing filter works fine on all columns that has multi choice filter in the Reporting page and Tags page
