### PR TITLE
Feature/376 add session expired message

### DIFF
--- a/packages/api/src/components/TokenIssuer.ts
+++ b/packages/api/src/components/TokenIssuer.ts
@@ -7,6 +7,7 @@ import { inject, singleton } from 'tsyringe'
 import { Configuration } from './Configuration'
 import { emptyObj } from '~utils/noop'
 import { DbUser } from '~db/types'
+import { AuthenticationError } from 'apollo-server-errors'
 
 export enum TokenPurpose {
 	Authentication = 'auth',
@@ -77,7 +78,9 @@ export class TokenIssuer {
 		return new Promise<DecodedToken | null>((resolve, _reject) => {
 			verify(token, this.config.jwtSecret, VERIFY_OPTIONS, (err, decoded) => {
 				if (err) {
-					resolve(null)
+					throw new AuthenticationError(`Invalid token`, {
+						error: err
+					})
 				} else {
 					resolve((decoded as any) ?? null)
 				}

--- a/packages/api/src/components/TokenIssuer.ts
+++ b/packages/api/src/components/TokenIssuer.ts
@@ -79,7 +79,7 @@ export class TokenIssuer {
 			verify(token, this.config.jwtSecret, VERIFY_OPTIONS, (err, decoded) => {
 				if (err) {
 					throw new AuthenticationError(`Invalid token`, {
-						error: err
+						tokenStatus: err.name
 					})
 				} else {
 					resolve((decoded as any) ?? null)

--- a/packages/api/src/components/__tests__/TokenIssuer.spec.ts
+++ b/packages/api/src/components/__tests__/TokenIssuer.spec.ts
@@ -49,17 +49,14 @@ describe('The TokenIssuer', () => {
 		// just past expiry
 		iat = hoursAgo(25)
 		token = await issuer.issueToken('user_1', TokenPurpose.Authentication, '24h', { iat })
-		decoded = await issuer.verifyAuthToken(token)
-		expect(decoded).toBeNull()
+		await expect(issuer.verifyAuthToken(token)).rejects.toThrow()
 	})
 
 	it('handles malformed tokens correctly', async () => {
 		const issuer = new TokenIssuer(config)
-		let result = await issuer.verifyAuthToken('snthaoeunshtaoesunth [908g3y')
-		expect(result).toBeNull()
+		await expect(issuer.verifyAuthToken('snthaoeunshtaoesunth [908g3y')).rejects.toThrow()
 
-		result = await issuer.verifyPasswordResetToken('snthaoeunshtaoesunth [908g3y')
-		expect(result).toBeNull()
+		await expect(issuer.verifyPasswordResetToken('snthaoeunshtaoesunth [908g3y')).rejects.toThrow()
 	})
 
 	it('can issue auth tokens', async () => {

--- a/packages/webapp/src/api/createErrorLink.ts
+++ b/packages/webapp/src/api/createErrorLink.ts
@@ -27,7 +27,7 @@ export function createErrorLink(history: History) {
 
 		// If auth error, navigate to login
 		if (graphQLErrors?.some((e) => e?.extensions?.code === UNAUTHENTICATED)) {
-			if (graphQLErrors?.some((e) => e?.extensions?.error?.name === TOKEN_EXPIRED_ERROR)) {
+			if (graphQLErrors?.some((e) => e?.extensions?.tokenStatus === TOKEN_EXPIRED_ERROR)) {
 				navigate(history, ApplicationRoute.Login, { error: TOKEN_EXPIRED })
 			} else {
 				navigate(history, ApplicationRoute.Login, { error: UNAUTHENTICATED })

--- a/packages/webapp/src/api/createErrorLink.ts
+++ b/packages/webapp/src/api/createErrorLink.ts
@@ -27,9 +27,15 @@ export function createErrorLink(history: History) {
 
 		// If auth error, navigate to login
 		if (graphQLErrors?.some((e) => e?.extensions?.code === UNAUTHENTICATED)) {
-			navigate(history, ApplicationRoute.Login, { error: UNAUTHENTICATED })
+			if (graphQLErrors?.some((e) => e?.extensions?.error?.name === TOKEN_EXPIRED_ERROR)) {
+				navigate(history, ApplicationRoute.Login, { error: TOKEN_EXPIRED })
+			} else {
+				navigate(history, ApplicationRoute.Login, { error: UNAUTHENTICATED })
+			}
 		}
 	})
 }
 
 const UNAUTHENTICATED = 'UNAUTHENTICATED'
+const TOKEN_EXPIRED = 'TOKEN_EXPIRED'
+const TOKEN_EXPIRED_ERROR = 'TokenExpiredError'

--- a/packages/webapp/src/components/ui/LoginPageBody/index.tsx
+++ b/packages/webapp/src/components/ui/LoginPageBody/index.tsx
@@ -66,6 +66,9 @@ function usePathError(): string | undefined {
 		if (errorArg === 'UNAUTHENTICATED') {
 			setError(c('errors.unauthenticated'))
 		}
+		if (errorArg === 'TOKEN_EXPIRED') {
+			setError(c('errors.tokenExpired'))
+		}
 	}, [errorArg, c])
 	return error
 }

--- a/packages/webapp/src/locales/en-US/common.json
+++ b/packages/webapp/src/locales/en-US/common.json
@@ -103,7 +103,9 @@
   },
   "errors": {
     "unauthenticated": "The email address or password you entered is incorrect. Please try again.",
-    "_unauthenticated.comment": "Invalid authentication token message"
+    "_unauthenticated.comment": "Invalid authentication token message",
+    "tokenExpired": "Session Expired. Please log in again.",
+    "_tokenExpired.comment": "Expired token message"
   },
   "utils": {
     "getTimeDuration": {


### PR DESCRIPTION
Fixes: #376 

**What** 
- Adds separate error for auth token expiry

**Why**
 - Provides the user a better idea of why they were logged out

**How**
 - Throw a graphql error with added context 

**Testing**
- Either wait 24h for your token to expire or update `authTokenExpiry` in the api config to a lower value

**Screenshots**

<img width="316" alt="Screen Shot 2022-04-17 at 10 08 12 PM" src="https://user-images.githubusercontent.com/25292393/163743428-a4ab7030-2a6f-4bef-859a-21f3311d7b41.png">

