### PR TITLE
#526 correct useHistory hook usage in navigation util

### DIFF
--- a/packages/webapp/src/utils/navigate.ts
+++ b/packages/webapp/src/utils/navigate.ts
@@ -17,7 +17,7 @@ export function navigate(
 	path: ApplicationRoute | null,
 	searchArgs: Record<string, any> = {}
 ): void {
-	const newPath = path == null ? history.location.path || '' : path
+	const newPath = path == null ? history.location.pathname || '' : path
 	const search = buildSearchString(history, searchArgs)
 	history.push(`${newPath}${search}`)
 }


### PR DESCRIPTION
**What** 
 - Fixed the issue that occur when defocusing client and specialist detail popover. It no longer results in navigating to the main page, but back to the correct view.

**Why**
 - The correct user experience is returning to the client or specialist list, not the request list.

**How**
 - Underlying issue was the incorrect use of the history hook from react-router-dom. It was trying to use a member `path` which didn't exist, when `pathname` was the correct member. When it didn't have the right path information it would default to the default request view. Now that we have the right info, it works as expected.

**Testing**
 - Breaks no existing tests.
 - Validated on local when defocusing the client and specialist popover to stay on the correct view.

**Screenshots**
[Updated Behavior Demo Video](https://user-images.githubusercontent.com/51097558/164103092-db6577ab-e5b3-470d-9f00-06d08024a160.mp4)

**Anything else**
Closes #526
