### PR TITLE
show decades first in date picker

### DIFF
--- a/packages/webapp/src/components/forms/AddClientForm/index.tsx
+++ b/packages/webapp/src/components/forms/AddClientForm/index.tsx
@@ -28,6 +28,7 @@ import { DatePicker } from '@fluentui/react'
 import { useLocale } from '~hooks/useLocale'
 import { emptyStr, noop } from '~utils/noop'
 import { StatusType } from '~hooks/api'
+import { DatePickerCalendar } from '~components/ui/DatePickerCalendar'
 
 interface AddClientFormProps {
 	title?: string
@@ -139,6 +140,8 @@ export const AddClientForm: StandardFC<AddClientFormProps> = wrap(function AddCl
 		}
 	}
 
+	const [isYearPickerVisible, setIsYearPickerVisible] = useState(false)
+
 	return (
 		<div className={cx(className, 'addClientForm')}>
 			<Formik
@@ -208,7 +211,7 @@ export const AddClientForm: StandardFC<AddClientFormProps> = wrap(function AddCl
 							<Row className='mb-4 pb-2'>
 								<Col>
 									<DatePicker
-										placeholder={t('addClient.fields.dateOfBirthPlaceholder')}
+										placeholder={'ddddddd'}
 										allowTextInput
 										showMonthPickerAsOverlay={false}
 										ariaLabel={c('formElements.datePickerAriaLabel')}
@@ -220,6 +223,29 @@ export const AddClientForm: StandardFC<AddClientFormProps> = wrap(function AddCl
 										maxDate={new Date()}
 										styles={DatePickerStyles}
 										className={styles.field}
+										calendarProps={{
+											calendarMonthProps: {
+												className: 'monthPicker',
+												componentRef: (ref) => {
+													// This is a hacky solution to show the years first instead of the months
+													// The alternative solution here is to use the calendarAs prop and create
+													// and entire custom component around this issue, which would most likely not
+													// be the best approach and take a lot longer to implement
+													// unfortunately, this is the best way to get the years to show first without
+													// having to create a custom component
+													if (ref) {
+														const monthPickerElement =
+															document.getElementsByClassName('monthPicker')
+														if (monthPickerElement.length > 0) {
+															(
+																monthPickerElement[0]?.firstElementChild
+																	?.firstChild as HTMLButtonElement
+															)?.click()
+														}
+													}
+												}
+											}
+										}}
 									/>
 								</Col>
 							</Row>

--- a/packages/webapp/src/components/forms/AddClientForm/index.tsx
+++ b/packages/webapp/src/components/forms/AddClientForm/index.tsx
@@ -229,8 +229,8 @@ export const AddClientForm: StandardFC<AddClientFormProps> = wrap(function AddCl
 												componentRef: (ref) => {
 													// This is a hacky solution to show the years first instead of the months
 													// The alternative solution here is to use the calendarAs prop and create
-													// and entire custom component around this issue, which would most likely not
-													// be the best approach and take a lot longer to implement
+													// and entire custom component around this issue, which would be more
+													// complex and more prone to errors
 													// unfortunately, this is the best way to get the years to show first without
 													// having to create a custom component
 													if (ref) {

--- a/packages/webapp/src/components/forms/AddClientForm/index.tsx
+++ b/packages/webapp/src/components/forms/AddClientForm/index.tsx
@@ -211,7 +211,7 @@ export const AddClientForm: StandardFC<AddClientFormProps> = wrap(function AddCl
 							<Row className='mb-4 pb-2'>
 								<Col>
 									<DatePicker
-										placeholder={'ddddddd'}
+										placeholder={t('addClient.fields.dateOfBirthPlaceholder')}
 										allowTextInput
 										showMonthPickerAsOverlay={false}
 										ariaLabel={c('formElements.datePickerAriaLabel')}

--- a/packages/webapp/src/components/forms/AddClientForm/index.tsx
+++ b/packages/webapp/src/components/forms/AddClientForm/index.tsx
@@ -28,7 +28,6 @@ import { DatePicker } from '@fluentui/react'
 import { useLocale } from '~hooks/useLocale'
 import { emptyStr, noop } from '~utils/noop'
 import { StatusType } from '~hooks/api'
-import { DatePickerCalendar } from '~components/ui/DatePickerCalendar'
 
 interface AddClientFormProps {
 	title?: string
@@ -139,8 +138,6 @@ export const AddClientForm: StandardFC<AddClientFormProps> = wrap(function AddCl
 			setSubmitButtonDisabledState(false)
 		}
 	}
-
-	const [isYearPickerVisible, setIsYearPickerVisible] = useState(false)
 
 	return (
 		<div className={cx(className, 'addClientForm')}>


### PR DESCRIPTION
Fixes: #419

**What** 
 - Show the decades view first when opening the calendar date picker

**How**
 - This uses a "hacky solution" to click the month/year button before the user can view the calendar
 - Unfortunately this was the best solution I could find without creating an entire custom component

**Anything else**
 - Some useful info for those who want to dig deeper into this bug:
      - Docs for Calendar Component: https://docs.microsoft.com/en-us/javascript/api/react-date-time/icalendarprops?view=office-ui-fabric-react-latest
      - The unchangeable private var in the library: https://github.com/microsoft/fluentui/blob/6fa3723d90e131f5f973ab622e03e39f78bd1642/packages/react/src/components/Calendar/CalendarMonth/CalendarMonth.base.tsx#L77

