### PR TITLE
Fix help menu icon size

### DIFF
--- a/packages/webapp/src/components/ui/HelpMenu/index.tsx
+++ b/packages/webapp/src/components/ui/HelpMenu/index.tsx
@@ -22,7 +22,7 @@ export const HelpMenu: React.FunctionComponent = () => {
 					aria-label='Help'
 					iconName='Help'
 					role='img'
-					className={mergeStyles({ fontSize: '28px' })}
+					className={mergeStyles({ fontSize: '20px' })}
 				/>
 			</div>
 			<ContextualMenu


### PR DESCRIPTION
**What** 
- a request was made to make the help icon menu smaller

**Why**
- icon was too large

**Screenshots**
<img width="203" alt="image" src="https://user-images.githubusercontent.com/95376249/165344119-7903d256-9e84-4b8b-bfe5-2e7e2ca66963.png">

