### PR TITLE
fix regression so underline is displayed for the active view

### DIFF
--- a/packages/webapp/src/components/ui/TopNav/index.module.scss
+++ b/packages/webapp/src/components/ui/TopNav/index.module.scss
@@ -13,6 +13,7 @@
 		color: color('text-light') !important;
 		font-weight: 600;
 		margin-right: 3rem;
+		position: relative;
 
 		&[class*='nav-active']::before {
 			content: '';


### PR DESCRIPTION
**What** 
 - fix regression so underline is displayed for the active view

**Why**
 - So it's evident what the active view is

**How**
 - fixed regression introduced by refactor of nav bar

**Screenshots**
![Screen Shot 2022-04-29 at 3 19 06 PM](https://user-images.githubusercontent.com/12299654/166043797-5a547379-b2f7-4429-98d1-b33812d72dd1.png)
