### PR TITLE
In kiosk mode, add client screen has gap above it

### DIFF
--- a/packages/webapp/src/components/ui/NewFormPanel/NewFormPanel.tsx
+++ b/packages/webapp/src/components/ui/NewFormPanel/NewFormPanel.tsx
@@ -18,13 +18,15 @@ interface NewFormPanelProps {
 	newFormPanelName?: string
 	onNewFormPanelSubmit?: (values: any, formName?: string) => void
 	onNewFormPanelDismiss?: () => void
+	kioskMode?: boolean
 }
 
 export const NewFormPanel: FC<NewFormPanelProps> = memo(function NewFormPanel({
 	showNewFormPanel = false,
 	newFormPanelName,
 	onNewFormPanelSubmit = noop,
-	onNewFormPanelDismiss = noop
+	onNewFormPanelDismiss = noop,
+	kioskMode = false
 }) {
 	const [isNewFormPanelOpen, { setTrue: openNewFormPanel, setFalse: dismissNewFormPanel }] =
 		useBoolean(false)
@@ -84,7 +86,11 @@ export const NewFormPanel: FC<NewFormPanelProps> = memo(function NewFormPanel({
 		}
 	}, [showNewFormPanel, newFormPanelName, openNewFormPanel, dismissNewFormPanel])
 	return (
-		<Panel openPanel={isNewFormPanelOpen} onDismiss={handleNewFormPanelDismiss}>
+		<Panel
+			openPanel={isNewFormPanelOpen}
+			kioskMode={kioskMode}
+			onDismiss={handleNewFormPanelDismiss}
+		>
 			{newFormPanelNameState && renderNewFormPanel(newFormPanelNameState)}
 		</Panel>
 	)

--- a/packages/webapp/src/components/ui/Panel/index.tsx
+++ b/packages/webapp/src/components/ui/Panel/index.tsx
@@ -5,21 +5,24 @@
 import type { IPanelStyles } from '@fluentui/react'
 import { Panel as FluentPanel, PanelType } from '@fluentui/react'
 import { useBoolean } from '@fluentui/react-hooks'
-import { memo, useEffect } from 'react'
+import { memo, useEffect, useMemo } from 'react'
 import type { StandardFC } from '~types/StandardFC'
 import { noop } from '~utils/noop'
 
 interface PanelProps {
 	onDismiss?: () => void
 	openPanel?: boolean
+	kioskMode?: boolean
 }
 
 export const Panel: StandardFC<PanelProps> = memo(function Panel({
 	children,
 	onDismiss = noop,
-	openPanel = false
+	openPanel = false,
+	kioskMode = false
 }) {
 	const [isOpen, { setTrue: openFluentPanel, setFalse: dismissPanel }] = useBoolean(false)
+	const panelStyle = usePanelStyle(kioskMode)
 
 	useEffect(() => {
 		openPanel ? openFluentPanel() : dismissPanel()
@@ -37,50 +40,55 @@ export const Panel: StandardFC<PanelProps> = memo(function Panel({
 			isOpen={isOpen}
 			onDismiss={handleOnDismiss}
 			type={PanelType.medium}
-			styles={panelStyles}
+			styles={panelStyle}
 		>
 			{children}
 		</FluentPanel>
 	)
 })
 
-// Source: https://developer.microsoft.com/en-us/fluentui#/controls/web/panel#IPanelStyles
-const panelStyles: Partial<IPanelStyles> = {
-	main: {
-		marginTop: 'var(--action-bar--height)'
-	},
-	overlay: {
-		marginTop: 'var(--action-bar--height)',
-		cursor: 'default'
-	},
-	commands: {
-		zIndex: '1'
-	},
-	scrollableContent: {
-		minHeight: '100%'
-	},
-	content: {
-		minHeight: '100%'
-	},
-	subComponentStyles: {
-		closeButton: {
-			root: {
-				backgroundColor: 'var(--bs-primary-light)',
-				borderRadius: '50%',
-				marginRight: 20,
-				width: 26,
-				height: 26
+function usePanelStyle(kioskMode) {
+	// Source: https://developer.microsoft.com/en-us/fluentui#/controls/web/panel#IPanelStyles
+	return useMemo<Partial<IPanelStyles>>(
+		() => ({
+			main: {
+				marginTop: kioskMode ? 0 : 'var(--action-bar--height)'
 			},
-			rootHovered: {
-				backgroundColor: 'var(--bs-primary-light)'
+			overlay: {
+				marginTop: kioskMode ? 0 : 'var(--action-bar--height)',
+				cursor: 'default'
 			},
-			rootPressed: {
-				backgroundColor: 'var(--bs-primary-light)'
+			commands: {
+				zIndex: '1'
 			},
-			icon: {
-				color: 'var(--bs-white)',
-				fontWeight: 600
+			scrollableContent: {
+				minHeight: '100%'
+			},
+			content: {
+				minHeight: '100%'
+			},
+			subComponentStyles: {
+				closeButton: {
+					root: {
+						backgroundColor: 'var(--bs-primary-light)',
+						borderRadius: '50%',
+						marginRight: 20,
+						width: 26,
+						height: 26
+					},
+					rootHovered: {
+						backgroundColor: 'var(--bs-primary-light)'
+					},
+					rootPressed: {
+						backgroundColor: 'var(--bs-primary-light)'
+					},
+					icon: {
+						color: 'var(--bs-white)',
+						fontWeight: 600
+					}
+				}
 			}
-		}
-	}
+		}),
+		[kioskMode]
+	)
 }

--- a/packages/webapp/src/pages/services/serviceEntry.tsx
+++ b/packages/webapp/src/pages/services/serviceEntry.tsx
@@ -70,6 +70,7 @@ const ServiceEntry: FC<{ service: Service; sid: string }> = ({ service, sid }) =
 				showNewFormPanel={openNewFormPanel}
 				newFormPanelName={newFormName}
 				onNewFormPanelDismiss={() => setOpenNewFormPanel(false)}
+				kioskMode={kioskMode}
 			/>
 
 			<div className={'serviceEntryPage' + (kioskMode ? ' mt-5' : '')}>


### PR DESCRIPTION
**What** 
 - In kiosk mode, add client panel is now rendered at the top of the page

**Why**
 - In kiosk mode the the navigation bar is not displayed, so we don't need to render the side panel below it

**How**
 - `kioskMode` prop is passed to the `Panel` component and the the `margin` style is adjusted accordingly.

**Testing**
 - From the "Services" page click the "Kiosk" button on a service where a client is added to the form. Click the "New Client" button, observe the form is rendered at the top of the page.

**Screenshots**
 - ![Screen Shot 2022-05-09 at 12 11 11 PM](https://user-images.githubusercontent.com/12299654/167452080-c81bb900-8343-4a33-93b2-3cfbaa373256.png)

**Anything else**
 - This change also impacts the "Add Request", "Quick Actions", and "Start Service" side panels. However these side panels currently can't be reached in kiosk mode.
