### PR TITLE
Kiosk mode should hide the customer support button in lower right

### DIFF
--- a/packages/webapp/src/pages/services/serviceEntry.tsx
+++ b/packages/webapp/src/pages/services/serviceEntry.tsx
@@ -62,6 +62,13 @@ const ServiceEntry: FC<{ service: Service; sid: string }> = ({ service, sid }) =
 		}
 	}
 
+	useEffect(() => {
+		const w = window as any
+		if (w.Beacon && kioskMode) {
+			w.Beacon('destroy')
+		}
+	}, [kioskMode])
+
 	return (
 		<>
 			<Title title={title} />


### PR DESCRIPTION
**What** 
 - When in kiosk mode, we no longer display the lower right customer support button

**Why**
 - Kiosk mode is intended to restrict access/data to the user

**How**
 -  In the `ServiceEntry` component, check kiosk mode flag and destroy the `Beacon` object

**Testing**
 - On the "Services" page click the "Kiosk" button. Note how that page compares to the page after clicking the "Start"  button.

**Screenshots**
 ![Screen Shot 2022-05-09 at 1 16 04 PM](https://user-images.githubusercontent.com/12299654/167462666-8ad5574a-f1c6-4215-a008-2e6fc3c10800.png)
