### PR TITLE
Added util to disable submit buttons in form

### DIFF
--- a/packages/webapp/src/components/ui/FormikButton/index.tsx
+++ b/packages/webapp/src/components/ui/FormikButton/index.tsx
@@ -7,10 +7,13 @@ import cx from 'classnames'
 import { memo } from 'react'
 import type { StandardFC } from '~types/StandardFC'
 import { noop } from '~utils/noop'
+import { useOffline } from '~hooks/useOffline'
+import { isDisabled } from '~utils/forms'
 
 interface FormikButtonProps {
 	text?: string
 	type?: string
+	enableOffline?: boolean
 	disabled?: boolean
 	onClick?: () => void
 }
@@ -20,12 +23,13 @@ export const FormikButton: StandardFC<FormikButtonProps> = memo(function FormikB
 	text,
 	onClick = noop,
 	type,
+	enableOffline = false,
 	disabled,
 	children
 }) {
 	return (
 		<DefaultButton
-			disabled={disabled}
+			disabled={isDisabled(useOffline(), enableOffline, disabled)}
 			className={cx('py-4', className)}
 			text={text}
 			onClick={onClick}

--- a/packages/webapp/src/components/ui/FormikSubmitButton/index.tsx
+++ b/packages/webapp/src/components/ui/FormikSubmitButton/index.tsx
@@ -7,10 +7,13 @@ import cx from 'classnames'
 import { memo } from 'react'
 import type { StandardFC } from '~types/StandardFC'
 import { noop } from '~utils/noop'
+import { useOffline } from '~hooks/useOffline'
+import { isDisabled } from '~utils/forms'
 
 interface FormikSubmitButtonProps {
 	text?: string
 	type?: string
+	enableOffline?: boolean
 	disabled?: boolean
 	onClick?: () => void
 }
@@ -22,11 +25,12 @@ export const FormikSubmitButton: StandardFC<FormikSubmitButtonProps> = memo(
 		onClick = noop,
 		disabled,
 		type = 'submit',
+		enableOffline = false,
 		children
 	}) {
 		return (
 			<PrimaryButton
-				disabled={disabled}
+				disabled={isDisabled(useOffline(), enableOffline, disabled)}
 				className={cx('py-4', className)}
 				text={text}
 				onClick={onClick}

--- a/packages/webapp/src/components/ui/HelpMenu/index.module.scss
+++ b/packages/webapp/src/components/ui/HelpMenu/index.module.scss
@@ -1,6 +1,8 @@
 .helpMenu {
 	padding-right: 10px;
 	padding-left: 10px;
+	padding-bottom: 3px;
 	cursor: pointer;
+	font-weight: bold;
 	letter-spacing: 0.09px;
 }

--- a/packages/webapp/src/components/ui/HelpMenu/index.tsx
+++ b/packages/webapp/src/components/ui/HelpMenu/index.tsx
@@ -22,7 +22,7 @@ export const HelpMenu: React.FunctionComponent = () => {
 					aria-label='Help'
 					iconName='Help'
 					role='img'
-					className={mergeStyles({ fontSize: '20px' })}
+					className={mergeStyles({ fontSize: '18px' })}
 				/>
 			</div>
 			<ContextualMenu

--- a/packages/webapp/src/utils/forms.ts
+++ b/packages/webapp/src/utils/forms.ts
@@ -58,3 +58,24 @@ export function isRequired(field: ServiceField): boolean {
 export function hasOptionFields(fieldType: ServiceFieldType) {
 	return fieldType === ServiceFieldType.SingleChoice || fieldType === ServiceFieldType.MultiChoice
 }
+
+/**
+ * is disabled based on offline status and if it is allowed to work in offline mode
+ *
+ * @param isOffline The boolen status for offline mode
+ * @param enabledOffline The boolean status if form input is allow to work offline
+ * @param disabled The boolean for normal disabled use
+ *
+ * @returns Boolean for disabled value
+ */
+
+export function isDisabled(
+	isOffline: boolean,
+	enabledOffline: boolean,
+	disabled: boolean
+): boolean {
+	if (enabledOffline) {
+		return disabled
+	}
+	return isOffline ? true : disabled
+}


### PR DESCRIPTION
**What** 
Added a small util to use as a flag for offline and attach it too the submit buttons 

**Why**
 - This util should should make it easier to switch behaviour between off and on. 

**How**
 - Was thinking that a util function that can be place in any disabled prop would make it easier to handle the offline switch without adding individual functions to each component.

**Testing**
- toggle the `enableOffline` prop and toggle the offline mode in the drop down menu


