### PR TITLE
Ensure loading status is reported to interface.

### DIFF
--- a/packages/webapp/src/components/lists/ReportList/reports/RequestReport/index.tsx
+++ b/packages/webapp/src/components/lists/ReportList/reports/RequestReport/index.tsx
@@ -37,7 +37,7 @@ export const RequestReport: FC<CommonReportProps> = memo(function RequestReport(
 		onTrackEvent
 	)
 
-	useRequestReportData(setUnfilteredData, setFilteredData)
+	const loading = useRequestReportData(setUnfilteredData, setFilteredData)
 	useRequestReportFilters(fieldFilters, setFieldFilters)
 	useRequestReportCsvFields(setCsvFields, getDemographicValue, hiddenFields)
 	useRequestReportFilterHelper(setFilterHelper)
@@ -53,7 +53,7 @@ export const RequestReport: FC<CommonReportProps> = memo(function RequestReport(
 			bodyRowClassName={styles.bodyRow}
 			paginatorContainerClassName={styles.paginatorContainer}
 			overFlowActiveClassName={styles.overFlowActive}
-			isLoading={false}
+			isLoading={loading}
 		/>
 	)
 })

--- a/packages/webapp/src/components/lists/ReportList/reports/RequestReport/useRequestReportData.ts
+++ b/packages/webapp/src/components/lists/ReportList/reports/RequestReport/useRequestReportData.ts
@@ -13,7 +13,7 @@ export function useRequestReportData(
 	setFilteredData: (data: unknown[]) => void
 ) {
 	const { userId, orgId } = useCurrentUser()
-	const { myEngagementList, engagementList } = useEngagementList(orgId, userId)
+	const { myEngagementList, engagementList, loading } = useEngagementList(orgId, userId)
 	const { inactiveEngagementList } = useInactiveEngagementList(orgId)
 
 	useEffect(
@@ -29,4 +29,5 @@ export function useRequestReportData(
 		},
 		[setUnfilteredData, setFilteredData, myEngagementList, engagementList, inactiveEngagementList]
 	)
+	return loading
 }


### PR DESCRIPTION
- allows correct message to be displayed during loading
- previously, this was hard-coded to false so loading message was not present


