### PR TITLE
572 kiosk mode service list page, 573 Form Entry Service Selection

### DIFF
--- a/packages/webapp/src/components/app/AuthorizedRoutes.tsx
+++ b/packages/webapp/src/components/app/AuthorizedRoutes.tsx
@@ -46,7 +46,8 @@ const ServiceEntry = lazy(
 export const AuthorizedRoutes: FC = memo(function AuthorizedRoutes() {
 	return (
 		<Switch>
-			<Route path={ApplicationRoute.ServiceKioskMode} component={ServiceEntry} />
+			<Route path={ApplicationRoute.ServiceEntryKiosk} component={ServiceEntry} />
+			<Route exact path={ApplicationRoute.ServicesKiosk} component={ServicesIndex} />
 			<>
 				<div className={styles.appContainer}>
 					<ContainerLayout>

--- a/packages/webapp/src/components/lists/ServiceList/columns.tsx
+++ b/packages/webapp/src/components/lists/ServiceList/columns.tsx
@@ -72,7 +72,12 @@ export function useColumns(onServiceClose: (service: Service) => void, isKiosk: 
 				className: isKiosk ? styles.serviceName : 'col-2',
 				onRenderColumnItem(service: Service) {
 					return (
-						<CardRowTitle tag='span' className='service-title' title={service.name} titleLink='/' />
+						<CardRowTitle
+							tag='span'
+							className='service-title'
+							title={service.name}
+							titleLink={isKiosk ? null : '/'}
+						/>
 					)
 				}
 			}

--- a/packages/webapp/src/components/lists/ServiceList/columns.tsx
+++ b/packages/webapp/src/components/lists/ServiceList/columns.tsx
@@ -84,7 +84,6 @@ export function useColumns(onServiceClose: (service: Service) => void, isKiosk: 
 		]
 		if (isKiosk) {
 			columns.push({
-				//TODO: should we open in new tab? - probably not, but how to return?
 				key: 'actions',
 				name: '',
 				className: styles.kioskActionButton,
@@ -92,7 +91,7 @@ export function useColumns(onServiceClose: (service: Service) => void, isKiosk: 
 					return (
 						<div
 							onClick={() =>
-								navigate(history, ApplicationRoute.ServiceEntryKiosk, { sid: service.id }, true)
+								navigate(history, ApplicationRoute.ServiceEntryKiosk, { sid: service.id })
 							}
 						>
 							<FontIcon iconName='ChevronRightSmall' />

--- a/packages/webapp/src/components/lists/ServiceList/index.module.scss
+++ b/packages/webapp/src/components/lists/ServiceList/index.module.scss
@@ -19,6 +19,10 @@
 	display: flex;
 	justify-content: flex-end;
 	color: color('gray-4');
+
+	i {
+		cursor: pointer;
+	}
 }
 
 .serviceName {

--- a/packages/webapp/src/components/lists/ServiceList/index.module.scss
+++ b/packages/webapp/src/components/lists/ServiceList/index.module.scss
@@ -2,7 +2,33 @@
  * Copyright (c) Microsoft. All rights reserved.
  * Licensed under the MIT license. See LICENSE file in the project.
  */
+
+.serviceListKiosk {
+	padding: 0 30px 0 30px;
+	width: 800px;
+}
+
 .actionButton {
 	border-radius: 20px;
 	width: 70px;
+}
+
+.kioskActionButton {
+	font-size: 20px;
+	display: flex;
+	justify-content: flex-end;
+}
+
+.serviceName {
+	font-style: normal;
+	font-weight: 400;
+	font-size: 32px;
+}
+
+.exitKioskModeButton {
+	width: 100%;
+	display: flex;
+	justify-content: flex-end;
+	font-weight: 400;
+	font-size: 12px;
 }

--- a/packages/webapp/src/components/lists/ServiceList/index.module.scss
+++ b/packages/webapp/src/components/lists/ServiceList/index.module.scss
@@ -2,6 +2,7 @@
  * Copyright (c) Microsoft. All rights reserved.
  * Licensed under the MIT license. See LICENSE file in the project.
  */
+@use '~styles/lib/colors' as *;
 
 .serviceListKiosk {
 	padding: 0 30px 0 30px;
@@ -17,6 +18,7 @@
 	font-size: 20px;
 	display: flex;
 	justify-content: flex-end;
+	color: color('gray-4');
 }
 
 .serviceName {

--- a/packages/webapp/src/components/lists/ServiceList/index.tsx
+++ b/packages/webapp/src/components/lists/ServiceList/index.tsx
@@ -80,6 +80,7 @@ export const ServiceList: StandardFC<ServiceListProps> = wrap(function ServiceLi
 				isLoading={loading}
 				hideSearch={isKiosk}
 				hideListHeaders={isKiosk}
+				hideRowBorders={isKiosk}
 			/>
 		</div>
 	)

--- a/packages/webapp/src/components/lists/ServiceList/index.tsx
+++ b/packages/webapp/src/components/lists/ServiceList/index.tsx
@@ -11,6 +11,8 @@ import type { Service } from '@cbosuite/schema/dist/client-types'
 import { Namespace, useTranslation } from '~hooks/useTranslation'
 import { wrap } from '~utils/appinsights'
 import { useCurrentUser } from '~hooks/api/useCurrentUser'
+import { useNavCallback } from '~hooks/useNavCallback'
+import { useAuthUser } from '~hooks/api/useAuth'
 import { useHistory } from 'react-router-dom'
 import { noop } from '~utils/noop'
 import { navigate } from '~utils/navigate'
@@ -20,6 +22,7 @@ import { ApplicationRoute } from '~types/ApplicationRoute'
 
 interface ServiceListProps {
 	title?: string
+	isKiosk?: boolean
 	services?: Service[]
 	loading?: boolean
 	onServiceClose?: (service: Service) => void
@@ -27,6 +30,7 @@ interface ServiceListProps {
 
 export const ServiceList: StandardFC<ServiceListProps> = wrap(function ServiceList({
 	title,
+	isKiosk,
 	services = [],
 	loading,
 	onServiceClose = noop
@@ -36,20 +40,46 @@ export const ServiceList: StandardFC<ServiceListProps> = wrap(function ServiceLi
 	const { isAdmin } = useCurrentUser()
 	const handleAddService = useHandleAddService(isAdmin)
 	const searchList = useServiceSearchHandler(services, setFilteredList)
-	const pageColumns = useColumns(onServiceClose)
+	const pageColumns = useColumns(onServiceClose, isKiosk)
+
+	const { logout } = useAuthUser()
+	const onLogout = useNavCallback(ApplicationRoute.Logout)
 
 	return (
-		<div className={cx('mt-5 mb-5', styles.serviceList, 'serviceList')}>
+		<div
+			className={cx(
+				'mt-5 mb-5',
+				styles.serviceList,
+				'serviceList',
+				isKiosk ? styles.serviceListKiosk : ''
+			)}
+		>
+			{isKiosk && (
+				<div className={styles.exitKioskModeButton}>
+					<button
+						className='btn btn-link text-decoration-none'
+						type='button'
+						onClick={() => {
+							logout()
+							onLogout()
+						}}
+					>
+						{t('servicesExitKioskMode')}
+					</button>
+				</div>
+			)}
 			<PaginatedList
 				title={title}
 				list={filteredList}
 				itemsPerPage={10}
 				columns={pageColumns}
 				rowClassName={'align-items-center'}
-				addButtonName={isAdmin ? t('serviceListAddButton') : undefined}
+				addButtonName={isAdmin && !isKiosk ? t('serviceListAddButton') : undefined}
 				onListAddButtonClick={handleAddService}
 				onSearchValueChange={searchList}
 				isLoading={loading}
+				hideSearch={isKiosk}
+				hideListHeaders={isKiosk}
 			/>
 		</div>
 	)

--- a/packages/webapp/src/components/ui/FormGenerator/index.module.scss
+++ b/packages/webapp/src/components/ui/FormGenerator/index.module.scss
@@ -9,6 +9,16 @@
 	padding: 20px;
 }
 
+.header {
+	display: flex;
+	justify-content: center;
+}
+
+.headerButton {
+	flex-grow: 2;
+	font-size: 11px;
+}
+
 .contactContainer {
 	border: 1px solid color('gray-4');
 	padding: 10px;

--- a/packages/webapp/src/components/ui/FormGenerator/index.tsx
+++ b/packages/webapp/src/components/ui/FormGenerator/index.tsx
@@ -19,9 +19,13 @@ import { ContactList } from './ContactList'
 import { FieldViewList } from './FieldViewList'
 import { ActionRow } from './ActionRow'
 import { ContactForm } from './ContactForm'
+import { IconButton } from '~components/ui/IconButton'
 import { useContactSynchronization, useSubmitHandler } from './hooks'
+import { Namespace, useTranslation } from '~hooks/useTranslation'
 import { ServiceHeader } from './ServiceHeader'
-
+import { useHistory } from 'react-router-dom'
+import { navigate } from '~utils/navigate'
+import { ApplicationRoute } from '~types/ApplicationRoute'
 interface FormGeneratorProps {
 	service: Service
 	previewMode?: boolean
@@ -50,6 +54,8 @@ export const FormGenerator: StandardFC<FormGeneratorProps> = memo(function FormG
 	const handleSubmit = useSubmitHandler(mgr, contacts, onSubmit)
 	useContactSynchronization(mgr, record, editMode, setContacts)
 	const isContactFormShown = !editMode && service?.contactFormEnabled
+	const { t } = useTranslation(Namespace.Services)
+	const history = useHistory()
 
 	return (
 		<div
@@ -58,7 +64,24 @@ export const FormGenerator: StandardFC<FormGeneratorProps> = memo(function FormG
 			})}
 		>
 			<Container>
-				<ServiceHeader service={service} />
+				<div className={styles.header}>
+					{kioskMode && (
+						<IconButton
+							className={styles.headerButton}
+							icon='ChevronLeft'
+							text={t('serviceReturnToServices')}
+							onClick={() => {
+								navigate(history, ApplicationRoute.ServicesKiosk)
+							}}
+						/>
+					)}
+					<ServiceHeader service={service} />
+					{
+						kioskMode && (
+							<div className={styles.headerButton}></div>
+						) /* Invisible flex item to keep service title centered */
+					}
+				</div>
 				{isContactFormShown && (
 					<ContactForm
 						mgr={mgr}

--- a/packages/webapp/src/components/ui/PaginatedList/PaginatedData.tsx
+++ b/packages/webapp/src/components/ui/PaginatedList/PaginatedData.tsx
@@ -20,6 +20,7 @@ import { OfflineTableNoticeOrNoResults } from '../OfflineTableNoticeOrNoResults'
 export interface PaginatedDataProps<T> extends StandardComponentProps {
 	data: T[]
 	columns: IPaginatedListColumn[]
+	hideRowBorders?: boolean
 	isLoading: boolean
 	isSearching: boolean
 	itemsPerPage: number
@@ -31,6 +32,7 @@ export interface PaginatedDataProps<T> extends StandardComponentProps {
 export const PaginatedData = memo(function PaginatedData<T>({
 	className,
 	rowClassName,
+	hideRowBorders = false,
 	data,
 	columns,
 	itemsPerPage,
@@ -62,12 +64,26 @@ export const PaginatedData = memo(function PaginatedData<T>({
 				<>
 					{pageItems(data, items, isSearching).length > 0 ? (
 						pageItems(data, items, isSearching).map((item: T, id: number) => (
-							<Row key={id} className={cx(styles.itemRow, rowClassName, 'data-row')}>
+							<Row
+								key={id}
+								className={cx(
+									styles.itemRow,
+									hideRowBorders ? '' : styles.itemRowBordered,
+									rowClassName,
+									'data-row'
+								)}
+							>
 								{columns.map((column: any, idx: number) => renderColumnItem(column, item, idx))}
 							</Row>
 						))
 					) : (
-						<Row className={cx(styles.itemRow, rowClassName)}>
+						<Row
+							className={cx(
+								styles.itemRow,
+								hideRowBorders ? '' : styles.itemRowBordered,
+								rowClassName
+							)}
+						>
 							<Col className={cx(styles.columnItem, styles.noResults)}>
 								<OfflineTableNoticeOrNoResults />
 							</Col>

--- a/packages/webapp/src/components/ui/PaginatedList/PaginatedList.tsx
+++ b/packages/webapp/src/components/ui/PaginatedList/PaginatedList.tsx
@@ -30,6 +30,7 @@ export const PaginatedList = memo(function PaginatedList<T>({
 	paginatorContainerClassName,
 	listItemsContainerClassName,
 	hideListHeaders = false,
+	hideSearch = false,
 	addButtonName,
 	exportButtonName,
 	isMD = true,
@@ -161,14 +162,16 @@ export const PaginatedList = memo(function PaginatedList<T>({
 							collapsibleOpen={isOpen}
 						/>
 					)}
-					<ListSearch
-						className='list-search'
-						collapsible={collapsible}
-						collapsibleOpen={isOpen}
-						filterOptions={filterOptions}
-						showSearch={showSearch}
-						onSearchChange={handleSearchValueChanged}
-					/>
+					{!hideSearch && (
+						<ListSearch
+							className='list-search'
+							collapsible={collapsible}
+							collapsibleOpen={isOpen}
+							filterOptions={filterOptions}
+							showSearch={showSearch}
+							onSearchChange={handleSearchValueChanged}
+						/>
+					)}
 					<ActionButtons
 						collapsible={collapsible}
 						collapsibleOpen={isOpen}

--- a/packages/webapp/src/components/ui/PaginatedList/PaginatedList.tsx
+++ b/packages/webapp/src/components/ui/PaginatedList/PaginatedList.tsx
@@ -31,6 +31,7 @@ export const PaginatedList = memo(function PaginatedList<T>({
 	listItemsContainerClassName,
 	hideListHeaders = false,
 	hideSearch = false,
+	hideRowBorders = false,
 	addButtonName,
 	exportButtonName,
 	isMD = true,
@@ -146,7 +147,8 @@ export const PaginatedList = memo(function PaginatedList<T>({
 					'col',
 					isMD ? null : 'ps-2',
 					collapsible ? styles.listCollapse : '',
-					collapsible && isOpen ? styles.listCollapseOpen : ''
+					collapsible && isOpen ? styles.listCollapseOpen : '',
+					hideListHeaders ? styles.headerBorder : ''
 				)}
 			>
 				<div className={cx('row mb-3', listTitle ? 'align-items-end' : 'align-items-center')}>
@@ -203,6 +205,7 @@ export const PaginatedList = memo(function PaginatedList<T>({
 							className={listItemsContainerClassName}
 							overflowActiveClassName={overflowActiveClassName}
 							rowClassName={rowClassName}
+							hideRowBorders={hideRowBorders}
 							data={sortedList}
 							columns={columns}
 							isLoading={isLoading}

--- a/packages/webapp/src/components/ui/PaginatedList/index.module.scss
+++ b/packages/webapp/src/components/ui/PaginatedList/index.module.scss
@@ -8,6 +8,10 @@
 @use '~styles/lib/space' as *;
 @import '~styles/lib/arrows';
 
+.headerBorder {
+	border-bottom: 1px solid color('gray-4');
+}
+
 .columnHeaderRow {
 	border-bottom: 1px solid color('gray-5');
 	display: flex;
@@ -35,7 +39,6 @@
 	margin-left: 0;
 	margin-right: 0;
 	@media (min-width: 769px) {
-		border-bottom: 1px solid color('gray-2');
 		transition: background-color transition();
 		&:hover {
 			background-color: color('primary-alt-light');
@@ -44,6 +47,9 @@
 					opacity: 1;
 				}
 			}
+		}
+		&.itemRowBordered {
+			border-bottom: 1px solid color('gray-2');
 		}
 	}
 }

--- a/packages/webapp/src/components/ui/PaginatedList/types.ts
+++ b/packages/webapp/src/components/ui/PaginatedList/types.ts
@@ -40,6 +40,7 @@ export interface PaginatedListProps<T> extends StandardComponentProps {
 	listItemsContainerClassName?: string
 	hideListHeaders?: boolean
 	hideSearch?: boolean
+	hideRowBorders?: boolean
 	addButtonName?: string
 	exportButtonName?: string
 	isMD?: boolean

--- a/packages/webapp/src/components/ui/PaginatedList/types.ts
+++ b/packages/webapp/src/components/ui/PaginatedList/types.ts
@@ -39,6 +39,7 @@ export interface PaginatedListProps<T> extends StandardComponentProps {
 	overflowActiveClassName?: string
 	listItemsContainerClassName?: string
 	hideListHeaders?: boolean
+	hideSearch?: boolean
 	addButtonName?: string
 	exportButtonName?: string
 	isMD?: boolean

--- a/packages/webapp/src/locales/en-US/services.json
+++ b/packages/webapp/src/locales/en-US/services.json
@@ -5,6 +5,8 @@
   "_servicesTitle.comment": "List header title for the list of services",
   "servicesExitKioskMode": "Exit Kiosk Mode",
   "_servicesExitKioskMode.comment": "Exit kiosk mode button text for leaving kiosk mode",
+  "serviceReturnToServices": "All Services",
+  "_serviceReturnToServices.comment": "Return to services page button text",
   "serviceListColumns": {
     "name": "Service Information",
     "_name.comment": "Name column header label of the list",

--- a/packages/webapp/src/locales/en-US/services.json
+++ b/packages/webapp/src/locales/en-US/services.json
@@ -3,6 +3,8 @@
   "_pageTitle.comment": "Page title displayed in the browser tab",
   "servicesTitle": "Services",
   "_servicesTitle.comment": "List header title for the list of services",
+  "servicesExitKioskMode": "Exit Kiosk Mode",
+  "_servicesExitKioskMode.comment": "Exit kiosk mode button text for leaving kiosk mode",
   "serviceListColumns": {
     "name": "Service Information",
     "_name.comment": "Name column header label of the list",

--- a/packages/webapp/src/pages/services/index.tsx
+++ b/packages/webapp/src/pages/services/index.tsx
@@ -4,6 +4,7 @@
  */
 import type { FC } from 'react'
 import { useCallback, useMemo, useRef } from 'react'
+import { useLocation } from 'react-router-dom'
 import { ServiceList } from '~components/lists/ServiceList'
 import { useServiceList } from '~hooks/api/useServiceList'
 import { useCurrentUser } from '~hooks/api/useCurrentUser'
@@ -14,6 +15,7 @@ import { ArchiveServiceModal } from '~components/ui/ArchiveServiceModal'
 import { Title } from '~components/ui/Title'
 import { wrap } from '~utils/appinsights'
 import { useBoolean } from '@fluentui/react-hooks'
+import { ApplicationRoute } from '~types/ApplicationRoute'
 
 const ServicesPage: FC = wrap(function Services() {
 	const { orgId } = useCurrentUser()
@@ -22,6 +24,8 @@ const ServicesPage: FC = wrap(function Services() {
 	const [isModalShown, { setFalse: hideModal, setTrue: showModal }] = useBoolean(false)
 	const serviceInput = useRef(null)
 	const title = t('pageTitle')
+	const location = useLocation()
+	const isKiosk = location.pathname === ApplicationRoute.ServicesKiosk
 
 	const handleServiceClose = useCallback(
 		(values: Service) => {
@@ -55,6 +59,7 @@ const ServicesPage: FC = wrap(function Services() {
 			<Title title={title} />
 			<ServiceList
 				title={title}
+				isKiosk={isKiosk}
 				services={activeServiceList}
 				loading={loading}
 				onServiceClose={handleServiceClose}

--- a/packages/webapp/src/pages/services/serviceEntry.tsx
+++ b/packages/webapp/src/pages/services/serviceEntry.tsx
@@ -31,7 +31,7 @@ const ServiceEntry: FC<{ service: Service; sid: string }> = ({ service, sid }) =
 	const { addEngagement: addRequest } = useEngagementList()
 	const { orgId } = useCurrentUser()
 	const location = useLocation()
-	const kioskMode = location.pathname === ApplicationRoute.ServiceKioskMode
+	const kioskMode = location.pathname === ApplicationRoute.ServiceEntryKiosk
 
 	const { logout } = useAuthUser()
 	const onLogout = useNavCallback(ApplicationRoute.Logout)

--- a/packages/webapp/src/types/ApplicationRoute.ts
+++ b/packages/webapp/src/types/ApplicationRoute.ts
@@ -16,5 +16,6 @@ export enum ApplicationRoute {
 	AddService = '/services/addService',
 	EditService = '/services/editService',
 	ServiceEntry = '/services/serviceEntry',
-	ServiceKioskMode = '/services/serviceKioskMode'
+	ServiceEntryKiosk = '/services/serviceEntryKiosk',
+	ServicesKiosk = '/servicesKiosk'
 }


### PR DESCRIPTION
**What** 
 - Created a kiosk mode service list page where only action is to start a service in kiosk mode. Page also has a button a the top that when clicked triggers a logout. Currently the only way to get to navigate to the services list page is kiosk mode is to start a service in kiosk mode, the click the "All Services" button at the top.

**Why**
 - Allows a user to select a service in kiosk mode

**How**
 - Service list page detects if we're in kiosk mode and uses a flag to determine what elements to hide, and what styling to use.
 
**Testing**
 - From services page, start a service in kiosk mode, click "All Services" button at the top of the service form

**Screenshots**

![Screen Shot 2022-05-17 at 11 03 35 AM](https://user-images.githubusercontent.com/12299654/168844262-09c29fa0-f7f8-4cad-a8a2-a9d97b3682a5.png)

![Screen Shot 2022-05-17 at 11 03 19 AM](https://user-images.githubusercontent.com/12299654/168844266-4c0de142-81e0-4133-a364-989a7bbf7656.png)

![Kapture 2022-05-17 at 10 54 15](https://user-images.githubusercontent.com/12299654/168844268-8c7c9ee9-e64e-435c-bafb-140fb80a3601.gif)
 