### PR TITLE
Offline label - shows menu opt not permanent

### DIFF
--- a/packages/webapp/src/components/ui/Persona/index.tsx
+++ b/packages/webapp/src/components/ui/Persona/index.tsx
@@ -60,7 +60,7 @@ export const Persona: StandardFC = memo(function Persona({ className }) {
 
 		contextMenuItems.push({
 			key: 'toggleOffline',
-			text: `${isOffline ? 'Disable' : 'Enable'} Offline Mode`,
+			text: 'Test Offline Mode',
 			className: 'toggle-offline',
 			onClick: () => {
 				if (isOffline) {

--- a/packages/webapp/src/components/ui/Persona/index.tsx
+++ b/packages/webapp/src/components/ui/Persona/index.tsx
@@ -60,7 +60,7 @@ export const Persona: StandardFC = memo(function Persona({ className }) {
 
 		contextMenuItems.push({
 			key: 'toggleOffline',
-			text: 'Test Offline Mode',
+			text: `${isOffline ? c('personaMenu.disable') : ''} ${c('personaMenu.testOffline')}`,
 			className: 'toggle-offline',
 			onClick: () => {
 				if (isOffline) {

--- a/packages/webapp/src/locales/en-US/common.json
+++ b/packages/webapp/src/locales/en-US/common.json
@@ -32,6 +32,8 @@
   "personaTitle": "[[firstName]]",
   "_personaTitle.comment": "Hello string to greet logged-in user. {Placeholder = [,firstName,]}",
   "personaMenu": {
+    "testOffline": "Test Offline Mode",
+    "disable": "Disable",
     "accountText": "Account",
     "_accountText.comment": "Persona menu navigation item for Account page",
     "logoutText": "Logout",


### PR DESCRIPTION
**What** 
Change label that controls offline mode

**Why**
The original label made the feature appear to be permanent 

**How**
Changed the text

**Testing**
The new label should say `Test Offline Mode`

**Screenshots**
<img width="218" alt="image" src="https://user-images.githubusercontent.com/95376249/170060396-bc82778f-d471-4636-a202-6eccc2f175f6.png">


