### PR TITLE
Detect offline mode

### DIFF
--- a/packages/webapp/config/default.json
+++ b/packages/webapp/config/default.json
@@ -17,7 +17,8 @@
 		"trademarksUrl": "",
 		"codeOfConductUrl": "",
 		"version": "",
-		"isOffline": false
+		"isOffline": false,
+		"offlineTimerInterval": 10000
 	},
 	"firebase": {
 		"apiKey": null,

--- a/packages/webapp/src/hooks/useOffline.ts
+++ b/packages/webapp/src/hooks/useOffline.ts
@@ -10,9 +10,18 @@ export function useOffline() {
 	const [isOffline, setIsOffline] = useState(localStorage.getItem('isOffline') === String(true))
 
 	useEffect(() => {
+		let onlineTimer: NodeJS.Timeout = null
+		const onlineInterval = config.site.offlineTimerInterval || 10000
+
 		const setOffline = () => {
+			clearTimeout(onlineTimer)
 			setIsOffline(true)
 			localStorage.setItem('isOffline', 'true')
+		}
+
+		const setOnlineInterval = () => {
+			clearTimeout(onlineTimer)
+			onlineTimer = setTimeout(setOnline, onlineInterval)
 		}
 
 		const setOnline = () => {
@@ -21,11 +30,11 @@ export function useOffline() {
 		}
 
 		window.addEventListener('offline', setOffline)
-		window.addEventListener('online', setOnline)
+		window.addEventListener('online', setOnlineInterval)
 
 		return () => {
 			window.removeEventListener('offline', setOffline)
-			window.removeEventListener('online', setOnline)
+			window.removeEventListener('online', setOnlineInterval)
 		}
 	}, [setIsOffline])
 

--- a/packages/webapp/src/utils/config.ts
+++ b/packages/webapp/src/utils/config.ts
@@ -27,6 +27,7 @@ export interface Config {
 		codeOfConductUrl: string
 		version: string
 		isOffline: boolean
+		offlineTimerInterval: number
 	}
 	firebase: {
 		apiKey: string | null


### PR DESCRIPTION
Fixes: #583 

**What** 
 - This PR adds an interval to the offline mode switch to account for spotty connections 

**How**
 - A simple setTimeout function is used to achieve this behaviour
 
**Testing**
 - Toggle offline mode in your browsers developer tools, the default timeout is 10s, this is adjustable in the config file

**Anything else**
 - Personally I think this may be poor UX. In most cases, having a spotty internet connection will not be an issue, and for the users that manually enable their internet, for example: connecting to a wifi network, turing on data, disabling airplane mode, etc; they will now need to wait 10s to see their app change from offline to online. This wait period could be interpreted as something going wrong or not working. 
- The ticket states a 5 minute "test period", this is kind of rediculous for if someone connects to a wifi network, so i've set it to 10s, and made it configurable 