### PR TITLE
601 offline ability to add a service record while offline

### DIFF
--- a/packages/webapp/src/hooks/api/useServiceAnswerList/useAddServiceAnswerCallback.ts
+++ b/packages/webapp/src/hooks/api/useServiceAnswerList/useAddServiceAnswerCallback.ts
@@ -67,13 +67,29 @@ export function useAddServiceAnswerCallback(refetch: () => void): AddServiceAnsw
 					})
 				}
 
+				// Need to populate value and values when writing to the cache
+				const optiServiceAnswer = {
+					..._serviceAnswer,
+					fields: _serviceAnswer.fields.map((field) => {
+						const f = field
+
+						// Single field value
+						if (typeof field.value === 'undefined') f.value = null
+
+						// Multi field value
+						if (typeof field.values === 'undefined') f.values = null
+
+						return f
+					})
+				}
+
 				addServiceAnswers({
 					variables: { serviceAnswer },
 					optimisticResponse: {
 						createServiceAnswer: {
 							message: 'Success',
 							serviceAnswer: {
-								...serviceAnswer,
+								...optiServiceAnswer,
 								id: crypto.randomUUID(),
 								__typename: 'ServiceAnswer'
 							},

--- a/packages/webapp/src/hooks/api/useServiceAnswerList/useAddServiceAnswerCallback.ts
+++ b/packages/webapp/src/hooks/api/useServiceAnswerList/useAddServiceAnswerCallback.ts
@@ -2,11 +2,6 @@
  * Copyright (c) Microsoft. All rights reserved.
  * Licensed under the MIT license. See LICENSE file in the project.
  */
-
-/*!
- * Copyright (c) Microsoft. All rights reserved.
- * Licensed under the MIT license. See LICENSE file in the project.
- */
 import { gql, useMutation } from '@apollo/client'
 import type {
 	MutationCreateServiceAnswerArgs,

--- a/packages/webapp/src/hooks/api/useServiceAnswerList/useLoadServiceAnswersCallback.ts
+++ b/packages/webapp/src/hooks/api/useServiceAnswerList/useLoadServiceAnswersCallback.ts
@@ -10,8 +10,7 @@ import { empty } from '~utils/noop'
 
 const log = createLogger('use load service answers')
 
-//TODO: might need to change this to eliminate offset/limit - this caused issues with Engagements
-const GET_SERVICE_ANSWERS = gql`
+export const GET_SERVICE_ANSWERS = gql`
 	${ServiceAnswerFields}
 	query GetServiceAnswers($serviceId: String!, $offset: Int, $limit: Int) {
 		serviceAnswers(serviceId: $serviceId, offset: $offset, limit: $limit) {
@@ -21,7 +20,7 @@ const GET_SERVICE_ANSWERS = gql`
 `
 
 export function useLoadServiceAnswersCallback(serviceId?: string) {
-	const { data, /*loading,*/ error, fetchMore, refetch } = useQuery(GET_SERVICE_ANSWERS, {
+	const { data, loading, error, fetchMore, refetch } = useQuery(GET_SERVICE_ANSWERS, {
 		variables: { serviceId }
 	})
 
@@ -40,6 +39,8 @@ export function useLoadServiceAnswersCallback(serviceId?: string) {
 
 	// If useQuery returns undefined, try using cache
 	const result = data?.serviceAnswers || cachedData?.serviceAnswers || empty
+	// If there's nothing in the cache but useQuery is loading, then we want to show a loading spinner
+	const waitingOnResult = result === empty ? loading : false
 
-	return { data: result, loading: false, refetch, fetchMore }
+	return { data: result, loading: waitingOnResult, refetch, fetchMore }
 }

--- a/packages/webapp/src/hooks/api/useServiceAnswerList/useLoadServiceAnswersCallback.ts
+++ b/packages/webapp/src/hooks/api/useServiceAnswerList/useLoadServiceAnswersCallback.ts
@@ -2,13 +2,15 @@
  * Copyright (c) Microsoft. All rights reserved.
  * Licensed under the MIT license. See LICENSE file in the project.
  */
-import { gql, useQuery } from '@apollo/client'
+import { gql, useQuery, useApolloClient } from '@apollo/client'
 import { useEffect } from 'react'
 import { ServiceAnswerFields } from '../fragments'
 import { createLogger } from '~utils/createLogger'
 import { empty } from '~utils/noop'
+
 const log = createLogger('use load service answers')
 
+//TODO: might need to change this to eliminate offset/limit - this caused issues with Engagements
 const GET_SERVICE_ANSWERS = gql`
 	${ServiceAnswerFields}
 	query GetServiceAnswers($serviceId: String!, $offset: Int, $limit: Int) {
@@ -19,9 +21,15 @@ const GET_SERVICE_ANSWERS = gql`
 `
 
 export function useLoadServiceAnswersCallback(serviceId?: string) {
-	const { data, loading, error, fetchMore, refetch } = useQuery(GET_SERVICE_ANSWERS, {
-		variables: { serviceId },
-		skip: serviceId == null
+	const { data, /*loading,*/ error, fetchMore, refetch } = useQuery(GET_SERVICE_ANSWERS, {
+		variables: { serviceId }
+	})
+
+	const client = useApolloClient()
+
+	const cachedData = client.readQuery({
+		query: GET_SERVICE_ANSWERS,
+		variables: { serviceId }
 	})
 
 	useEffect(() => {
@@ -30,5 +38,8 @@ export function useLoadServiceAnswersCallback(serviceId?: string) {
 		}
 	}, [error])
 
-	return { data: data?.serviceAnswers || empty, loading, refetch, fetchMore }
+	// If useQuery returns undefined, try using cache
+	const result = data?.serviceAnswers || cachedData?.serviceAnswers || empty
+
+	return { data: result, loading: false, refetch, fetchMore }
 }


### PR DESCRIPTION
**What** 
 - Service entries can now be added in offline mode 

**Why**
 - So service entries can be created when offline

**How**
 - When a service entry is created, we add it to the client cache. When viewing service entries on the report page, we read directly from the cache if apollo's `userQuery` is in loading state

**Testing**
1. Go to the reports page while online and view the services (this needs to be done because there is an issue with viewing services while offline)
2. Go to the 'Services' page while online
3. Enable offline mode
4. create a service entry
5. go to report page, see that the service entry is displayed
6. disable offline, ensure service entry is still there


**Anything else**
 - Service entries that have clients, do not work.
