### PR TITLE
offline mode - disable telemetry

### DIFF
--- a/packages/webapp/src/components/app/Measured.tsx
+++ b/packages/webapp/src/components/app/Measured.tsx
@@ -5,17 +5,20 @@
 import { AppInsightsContext } from '@microsoft/applicationinsights-react-js'
 import type { FC, ReactNode } from 'react'
 import { Component, memo, useEffect } from 'react'
-import { reactPlugin, isTelemetryEnabled } from '~utils/appinsights'
+import { reactPlugin, isTelemetryEnabled, setTelemetryTracking } from '~utils/appinsights'
 import { useLocation } from 'react-router-dom'
 import Redbox from 'redbox-react'
 import { useLocationQuery } from '~hooks/useLocationQuery'
 import { createLogger } from '~utils/createLogger'
 import { config } from '~utils/config'
+import { useOffline } from '~hooks/useOffline'
 const logger = createLogger('measured')
 
 const Tracking: FC = memo(function Tracking({ children }) {
 	const location = useLocation()
 	const query = useLocationQuery()
+	const isOffline = useOffline()
+	setTelemetryTracking(isOffline)
 	useEffect(() => {
 		if (isTelemetryEnabled()) {
 			if (typeof location !== 'undefined') {
@@ -49,6 +52,7 @@ export class Measured extends Component<{ children: ReactNode }, { error?: Error
 	public render() {
 		const { children } = this.props
 		const { error } = this.state
+
 		if (error && config.features.redbox.enabled) {
 			if (config.features.redbox.behavior === 'text-only') {
 				return <div className='errorMessage'>{`${error.message}\n\n${error.stack}`}</div>

--- a/packages/webapp/src/utils/appinsights.ts
+++ b/packages/webapp/src/utils/appinsights.ts
@@ -28,6 +28,10 @@ export const appInsights = new ApplicationInsights({
 })
 appInsights.loadAppInsights()
 
+export function setTelemetryTracking(isEnabled: boolean) {
+	appInsights.config.disableTelemetry = isEnabled
+}
+
 export function wrap<T extends ComponentType<unknown>>(
 	component: T,
 	componentName?: string,

--- a/packages/webapp/src/utils/appinsights.ts
+++ b/packages/webapp/src/utils/appinsights.ts
@@ -28,8 +28,8 @@ export const appInsights = new ApplicationInsights({
 })
 appInsights.loadAppInsights()
 
-export function setTelemetryTracking(isEnabled: boolean) {
-	appInsights.config.disableTelemetry = isEnabled
+export function setTelemetryTracking(isDisabled: boolean) {
+	appInsights.config.disableTelemetry = isDisabled
 }
 
 export function wrap<T extends ComponentType<unknown>>(


### PR DESCRIPTION
**What** 
- insights telemetry was causing issues during offline line mode when left on

**Why**
- This should stop the insights telemetry from trying to make calls when in offline mode

**How**
 - Using the insight config & offline hook added a small method to toggle the disable for telemetry 

**Testing**
- Have the network tab open in inspector
- refresh browser
- look for `track` network call
- turn on offline mode
- refresh browser
- no `track` network call should appear

