### PR TITLE
619 offline mode add service entry that has a clients

### DIFF
--- a/packages/webapp/src/hooks/api/useServiceAnswerList/useAddServiceAnswerCallback.ts
+++ b/packages/webapp/src/hooks/api/useServiceAnswerList/useAddServiceAnswerCallback.ts
@@ -89,7 +89,6 @@ export function useAddServiceAnswerCallback(refetch: () => void): AddServiceAnsw
 
 						return f
 					}),
-					// TODO: consider empty contacts etc
 					contacts: _serviceAnswer.contacts.map((contactId) => {
 						const contact = cachedOrganizations?.organization.contacts.find(
 							(contact) => contact.id === contactId
@@ -131,7 +130,7 @@ export function useAddServiceAnswerCallback(refetch: () => void): AddServiceAnsw
 						}
 
 						cache.updateQuery(queryOptions, addOptimisticResponse)
-						// refetch() // TODO: not sure what refetch() does
+						refetch()
 					}
 				})
 				success(c('hooks.useServicelist.createAnswerSuccess'))
@@ -141,6 +140,6 @@ export function useAddServiceAnswerCallback(refetch: () => void): AddServiceAnsw
 				return false
 			}
 		},
-		[c, success, failure, /*refetch,*/ addServiceAnswers, orgId, client]
+		[c, success, failure, refetch, addServiceAnswers, orgId, client]
 	)
 }


### PR DESCRIPTION
**What** 
 - For service entries that have one or more clients, when creating the optimistic response that we use to update the cache when offline, we need to map the client ids to the full client objects. When the app is online, this mapping is done by the GQL resolvers.

**Why**
 - Without this change we can't see client properties when viewing service entries on the reporting page

**How**
 - We read the list of clients from the cache and map client ids to the client object

**Testing**
 - add a service entry with a client while offline
 - go to the reporting page and ensure client properties (first and last name etc) are displayed.
