### PR TITLE
Birthdate is only displayed in client card if it is set.

### DIFF
--- a/packages/webapp/src/components/ui/FormGenerator/ContactRow.tsx
+++ b/packages/webapp/src/components/ui/FormGenerator/ContactRow.tsx
@@ -28,11 +28,13 @@ export const ContactRow: FC<{ contact: Contact }> = memo(function ContactRow({ c
 						{contact.name.first} {contact.name.last}
 					</strong>
 				</div>
-				<div className='d-block mb-2'>
-					{/* TODO: localize this rogue string*/}
-					Birthdate:{' '}
-					<strong>{new Intl.DateTimeFormat(locale).format(new Date(contact.dateOfBirth))}</strong>
-				</div>
+				{contact.dateOfBirth && (
+					<div className='d-block mb-2'>
+						{/* TODO: localize this rogue string*/}
+						Birthdate:{' '}
+						<strong>{new Intl.DateTimeFormat(locale).format(new Date(contact.dateOfBirth))}</strong>
+					</div>
+				)}
 				<div className={styles.contactInfo}>
 					<ContactInfo contact={contactBlock} />
 				</div>


### PR DESCRIPTION
Fixes #586 

**What** 
If no birthdate is set for a client, then simply do not display that field in the client card when entering a service entry.

**Why**
The application currently displayed 1969-12-31 as birthdate if it was not provided for the client.

**Screenshots**
![image](https://user-images.githubusercontent.com/20339669/173427959-e9aefea4-9f25-49b9-af5a-aa41929373e5.png)

