### PR TITLE
Feature/591 scan form

### DIFF
--- a/packages/webapp/config/ci.json
+++ b/packages/webapp/config/ci.json
@@ -11,6 +11,9 @@
 		},
 		"offlineMode": {
 			"enabled": true
+		},
+		"takePhotoMode": {
+			"enabled": false
 		}
 	}
 }

--- a/packages/webapp/config/custom-environment-variables.json
+++ b/packages/webapp/config/custom-environment-variables.json
@@ -28,6 +28,9 @@
 		},
 		"offlineMode": {
 			"enabled": "OFFLINE_MODE_ENABLED"
+		},
+		"takePhotoMode": {
+			"enabled": "TAKE_PHOTO_MODE_ENABLED"
 		}
 	}
 }

--- a/packages/webapp/config/default.json
+++ b/packages/webapp/config/default.json
@@ -61,6 +61,9 @@
 		},
 		"offlineMode": {
 			"enabled": false
+		},
+		"takePhotoMode": {
+			"enabled": false
 		}
 	}
 }

--- a/packages/webapp/config/development.json
+++ b/packages/webapp/config/development.json
@@ -26,6 +26,9 @@
 		},
 		"offlineMode": {
 			"enabled": true
+		},
+		"takePhotoMode": {
+			"enabled": false
 		}
 	}
 }

--- a/packages/webapp/src/components/app/AuthorizedRoutes.tsx
+++ b/packages/webapp/src/components/app/AuthorizedRoutes.tsx
@@ -26,6 +26,10 @@ import styles from './AuthorizedRoutes.module.scss'
 const NotFound = lazy(() => /* webpackChunkName: "NotFoundPage" */ import('~pages/404'))
 const Index = lazy(() => /* webpackChunkName: "IndexPage" */ import('~pages/index'))
 const Account = lazy(() => /* webpackChunkName: "AccountPage" */ import('~pages/account'))
+const ScanImage = lazy(() => /* webpackChunkName: "ScanImagePage" */ import('~pages/scanImage'))
+const ScanManager = lazy(
+	() => /* webpackChunkName: "ScanManagePage" */ import('~pages/scanManager')
+)
 const Clients = lazy(() => /* webpackChunkName: "ClientsPage" */ import('~pages/clients'))
 const Specialist = lazy(() => /* webpackChunkName: "SpecialistPage" */ import('~pages/specialist'))
 const Reporting = lazy(() => /* webpackChunkName: "ReportingPage" */ import('~pages/reporting'))
@@ -65,6 +69,8 @@ export const AuthorizedRoutes: FC = memo(function AuthorizedRoutes() {
 								<Route path={ApplicationRoute.EditService} component={EditService} />
 								<Route path={ApplicationRoute.ServiceEntry} component={ServiceEntry} />
 								{/* Slash path matches all. It's used as a catch-all here for not-found routes */}
+								<Route path={ApplicationRoute.ScanManager} component={ScanManager} />
+								<Route path={ApplicationRoute.ScanImage} component={ScanImage} />
 								<Route path={ApplicationRoute.Index} component={NotFound} />
 							</Switch>
 						</Suspense>

--- a/packages/webapp/src/components/ui/Persona/index.tsx
+++ b/packages/webapp/src/components/ui/Persona/index.tsx
@@ -45,14 +45,19 @@ export const Persona: StandardFC = memo(function Persona({ className }) {
 				logout()
 				onLogoutClick()
 			}
-		},
-		{
+		}
+	]
+	if (
+		['demo', 'staging', 'integ', 'local'].filter((env) => config.origin.includes(env)).length > 0 &&
+		config?.features?.takePhotoMode?.enabled
+	) {
+		contextMenuItems.push({
 			key: 'takePhoto',
 			text: c('personaMenu.takePhoto'),
 			className: 'toggle-offline',
 			onClick: onTakePhotoClick
-		}
-	]
+		})
+	}
 
 	// is the user env demo, staging, integ, or local
 	if (

--- a/packages/webapp/src/components/ui/Persona/index.tsx
+++ b/packages/webapp/src/components/ui/Persona/index.tsx
@@ -28,6 +28,7 @@ export const Persona: StandardFC = memo(function Persona({ className }) {
 	const lastName = currentUser?.name?.last || ''
 	const onAccountClick = useNavCallback(ApplicationRoute.Account)
 	const onLogoutClick = useNavCallback(ApplicationRoute.Logout)
+	const onTakePhotoClick = useNavCallback(ApplicationRoute.ScanManager)
 
 	const contextMenuItems = [
 		{
@@ -44,6 +45,12 @@ export const Persona: StandardFC = memo(function Persona({ className }) {
 				logout()
 				onLogoutClick()
 			}
+		},
+		{
+			key: 'takePhoto',
+			text: c('personaMenu.takePhoto'),
+			className: 'toggle-offline',
+			onClick: onTakePhotoClick
 		}
 	]
 

--- a/packages/webapp/src/components/ui/ScanImageBody/index.module.scss
+++ b/packages/webapp/src/components/ui/ScanImageBody/index.module.scss
@@ -1,0 +1,3 @@
+.scanImageComponentContainer {
+	padding: 20px;
+}

--- a/packages/webapp/src/components/ui/ScanImageBody/index.tsx
+++ b/packages/webapp/src/components/ui/ScanImageBody/index.tsx
@@ -1,0 +1,24 @@
+/*!
+ * Copyright (c) Microsoft. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project.
+ */
+import type { StandardFC } from '~types/StandardFC'
+import { memo } from 'react'
+import { ScanImagePanel } from '~components/ui/ScanImagePanel'
+import cx from 'classnames'
+import styles from './index.module.scss'
+
+interface ScanImageBodyProps {
+	onClose?: () => void
+	isLoaded?: (loaded: boolean) => void
+}
+
+export const ScanImageBody: StandardFC<ScanImageBodyProps> = memo(function ScanFormPanelBody() {
+	return (
+		<>
+			<div className={cx(styles.scanImageComponentContainer)}>
+				<ScanImagePanel />
+			</div>
+		</>
+	)
+})

--- a/packages/webapp/src/components/ui/ScanImagePanel/index.module.scss
+++ b/packages/webapp/src/components/ui/ScanImagePanel/index.module.scss
@@ -1,0 +1,33 @@
+@use '~styles/lib/colors' as *;
+
+.previewButtonContainer {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 6ch;
+}
+
+.photoContainer {
+	background-color: color('gray-3');
+	width: 640px;
+	height: 480px;
+}
+
+.takePhotoBottomButtonContainer {
+	padding-top: 25px;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 6ch;
+}
+
+.takePhotoTopButtonContainer {
+	padding-top: 25px;
+	padding-bottom: 25px;
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	gap: 6ch;
+}

--- a/packages/webapp/src/components/ui/ScanImagePanel/index.tsx
+++ b/packages/webapp/src/components/ui/ScanImagePanel/index.tsx
@@ -35,20 +35,12 @@ function useVideo(videoRef, canvasRef) {
 				if (!streaming) {
 					setVideoSize(videoRef)
 					setCanvasSize(canvasRef)
+
 					streaming = true
 				}
 			},
 			false
 		)
-
-		// takePhotoButtonRef.current.addEventListener('click', function(ev){
-		// 	takePicture(videoRef, canvasRef)
-		// }, false)
-		// return () => {
-		// 	if (takePhotoButtonRef.current !== null) {
-		// 		takePhotoButtonRef.current.removeEventListener()
-		// 	}
-		// }
 	}, [videoRef, canvasRef])
 }
 
@@ -77,14 +69,30 @@ function takePicture(videoRef, canvasRef) {
 }
 
 function startup(videoRef) {
-	navigator.mediaDevices.getUserMedia({ video: true, audio: false }).then(function (stream) {
+	// navigator.mediaDevices.getUserMedia({ audio: false, video: { facingMode: { exact: "environment" } } }).then(function (stream) {
+	// 	videoRef.current.srcObject = stream
+	// 	videoRef.current.play()
+	// })
+
+	// const supports = navigator.mediaDevices.getSupportedConstraints();
+	// if (!supports['facingMode']) {
+	// 	alert('This browser does not support facingMode!');
+	// }
+
+	const options = {
+		audio: false,
+		video: {
+			facingMode: 'environment' //'user', // Or 'environment'
+		}
+	}
+
+	navigator.mediaDevices.getUserMedia(options).then(function (stream) {
 		videoRef.current.srcObject = stream
 		videoRef.current.play()
 	})
 }
 
 interface ScanImagePanelProps {
-	// request?: { id: string; orgId: string }
 	onClose?: () => void
 	isLoaded?: (loaded: boolean) => void
 }
@@ -110,7 +118,6 @@ export const ScanImagePanel: StandardFC<ScanImagePanelProps> = memo(function Sca
 	const turnCameraOn = () => {
 		setVideoSize(videoRef)
 		setImageTakenState(false)
-		// startup(videoRef, canvasRef, takePhotoButtonRef)
 	}
 
 	const close = () => {
@@ -119,7 +126,6 @@ export const ScanImagePanel: StandardFC<ScanImagePanelProps> = memo(function Sca
 	}
 	const photoTaken = () => {
 		takePicture(videoRef, canvasRef)
-		// turnOffCamera(videoRef)
 		videoRef.current.pause()
 		videoRef.current.setAttribute('width', 0)
 		videoRef.current.setAttribute('height', 0)

--- a/packages/webapp/src/components/ui/ScanImagePanel/index.tsx
+++ b/packages/webapp/src/components/ui/ScanImagePanel/index.tsx
@@ -1,0 +1,203 @@
+/*!
+ * Copyright (c) Microsoft. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project.
+ */
+import type { StandardFC } from '~types/StandardFC'
+import { Namespace, useTranslation } from '~hooks/useTranslation'
+import { useEffect, memo, useState, useRef } from 'react'
+import { DefaultButton } from '@fluentui/react'
+import cx from 'classnames'
+import styles from './index.module.scss'
+import { useNavCallback } from '~hooks/useNavCallback'
+import { ApplicationRoute } from '~types/ApplicationRoute'
+
+const width = 640
+let height = 0
+let streaming = false
+// let imageData = null
+
+function setVideoSize(videoRef) {
+	height = videoRef.current.videoHeight / (videoRef.current.videoWidth / width)
+	videoRef.current.setAttribute('width', width)
+	videoRef.current.setAttribute('height', height)
+}
+
+function setCanvasSize(canvasRef) {
+	canvasRef.current.setAttribute('width', width)
+	canvasRef.current.setAttribute('height', height)
+}
+
+function useVideo(videoRef, canvasRef) {
+	useEffect(() => {
+		videoRef.current.addEventListener(
+			'canplay',
+			function (ev) {
+				if (!streaming) {
+					setVideoSize(videoRef)
+					setCanvasSize(canvasRef)
+					streaming = true
+				}
+			},
+			false
+		)
+
+		// takePhotoButtonRef.current.addEventListener('click', function(ev){
+		// 	takePicture(videoRef, canvasRef)
+		// }, false)
+		// return () => {
+		// 	if (takePhotoButtonRef.current !== null) {
+		// 		takePhotoButtonRef.current.removeEventListener()
+		// 	}
+		// }
+	}, [videoRef, canvasRef])
+}
+
+function clearPhoto(canvasRef) {
+	const context = canvasRef.current.getContext('2d')
+	context.fillStyle = '#AAA'
+	context.fillRect(0, 0, canvasRef.current.width, canvasRef.current.height)
+
+	// imageData = canvasRef.current.toDataURL('image/png')
+	// photoRef.current.setAttribute('src', imageData)
+}
+
+function takePicture(videoRef, canvasRef) {
+	const context = canvasRef.current.getContext('2d')
+	if (width && height) {
+		canvasRef.current.width = width
+		canvasRef.current.height = height
+		context.drawImage(videoRef.current, 0, 0, width, height)
+
+		// imageData = canvasRef.current.toDataURL('image/png')
+
+		// photoRef.current.setAttribute('src', imageData)
+	} else {
+		clearPhoto(canvasRef)
+	}
+}
+
+function startup(videoRef) {
+	navigator.mediaDevices.getUserMedia({ video: true, audio: false }).then(function (stream) {
+		videoRef.current.srcObject = stream
+		videoRef.current.play()
+	})
+}
+
+interface ScanImagePanelProps {
+	// request?: { id: string; orgId: string }
+	onClose?: () => void
+	isLoaded?: (loaded: boolean) => void
+}
+
+export const ScanImagePanel: StandardFC<ScanImagePanelProps> = memo(function ScanFormPanelBody({}) {
+	const videoRef = useRef(null)
+	const canvasRef = useRef(null)
+	const [isImageTaken, setImageTakenState] = useState<boolean>(false)
+	const { t } = useTranslation(Namespace.Scan)
+	const cancelTakePhoto = useNavCallback(ApplicationRoute.ScanManager)
+
+	const turnOffCamera = (videoRef) => {
+		const videoObj = videoRef.current.srcObject
+		const tracks = videoObj.getTracks()
+		if (tracks) {
+			streaming = false
+			videoRef.current.pause()
+			tracks.forEach((track) => track.stop())
+			videoRef.current.srcObject = null
+		}
+	}
+
+	const turnCameraOn = () => {
+		setVideoSize(videoRef)
+		setImageTakenState(false)
+		// startup(videoRef, canvasRef, takePhotoButtonRef)
+	}
+
+	const close = () => {
+		turnOffCamera(videoRef)
+		cancelTakePhoto()
+	}
+	const photoTaken = () => {
+		takePicture(videoRef, canvasRef)
+		// turnOffCamera(videoRef)
+		videoRef.current.pause()
+		videoRef.current.setAttribute('width', 0)
+		videoRef.current.setAttribute('height', 0)
+		setImageTakenState(true)
+	}
+
+	const turnOnFlash = () => {}
+
+	startup(videoRef)
+	useVideo(videoRef, canvasRef)
+
+	const videoStyle = {
+		display: isImageTaken ? 'none' : 'block'
+	}
+	const imageStyle = {
+		display: isImageTaken ? 'block' : 'none'
+	}
+	return (
+		<>
+			<div className={cx(styles.takePhotoTopButtonContainer)}>
+				<DefaultButton
+					style={videoStyle}
+					onClick={() => {
+						close()
+					}}
+					text={t('scanImage.cancelButton')}
+				/>
+				<DefaultButton
+					style={videoStyle}
+					disabled={true}
+					onClick={() => {
+						turnOnFlash()
+					}}
+					text={t('scanImage.turnOnFlashButton')}
+				/>
+			</div>
+			<div className={cx(styles.photoContainer)}>
+				{/* 640 */}
+				<canvas style={imageStyle} ref={canvasRef} id='canvas' />
+				<video ref={videoRef} id='video'>
+					<track kind='captions' />
+					{t('scanImage.videoStremNotWorking')}
+				</video>
+			</div>
+			{isImageTaken ? (
+				<>
+					<div className={cx(styles.previewButtonContainer)}>
+						<h2>{t('scanImage.previewPhotoText')}</h2>
+						<DefaultButton
+							style={imageStyle}
+							primary={true}
+							onClick={() => {
+								turnCameraOn()
+							}}
+							text={t('scanImage.takeMoreButton')}
+						/>
+						<DefaultButton
+							style={imageStyle}
+							onClick={() => {
+								close()
+							}}
+							text={t('scanImage.doneUploadButton')}
+						/>
+					</div>
+				</>
+			) : (
+				<>
+					<div className={cx(styles.takePhotoBottomButtonContainer)}>
+						<DefaultButton
+							style={videoStyle}
+							onClick={() => {
+								photoTaken()
+							}}
+							text={t('scanImage.takePhotoButton')}
+						/>
+					</div>
+				</>
+			)}
+		</>
+	)
+})

--- a/packages/webapp/src/components/ui/ScanManagerBody/index.module.scss
+++ b/packages/webapp/src/components/ui/ScanManagerBody/index.module.scss
@@ -1,0 +1,3 @@
+.scanManagerTopButtonContainer {
+	padding: 60px;
+}

--- a/packages/webapp/src/components/ui/ScanManagerBody/index.tsx
+++ b/packages/webapp/src/components/ui/ScanManagerBody/index.tsx
@@ -1,0 +1,40 @@
+/*!
+ * Copyright (c) Microsoft. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project.
+ */
+import type { StandardFC } from '~types/StandardFC'
+import { Namespace, useTranslation } from '~hooks/useTranslation'
+import { memo } from 'react'
+import { DefaultButton } from '@fluentui/react/lib/Button'
+import cx from 'classnames'
+import styles from './index.module.scss'
+import type { IIconProps } from '@fluentui/react'
+import { useNavCallback } from '~hooks/useNavCallback'
+import { ApplicationRoute } from '~types/ApplicationRoute'
+
+interface ScanManagerBodyProps {
+	onClose?: () => void
+	isLoaded?: (loaded: boolean) => void
+}
+
+export const ScanManagerBody: StandardFC<ScanManagerBodyProps> = memo(
+	function ScanFormPanelBody({}) {
+		const onTakePhotoClick = useNavCallback(ApplicationRoute.ScanImage)
+		const { t } = useTranslation(Namespace.Scan)
+		const circleIcon: IIconProps = { iconName: 'CircleShapeSolid' }
+
+		return (
+			<>
+				<div className={cx(styles.scanManagerTopButtonContainer)}>
+					<DefaultButton
+						text={t('scanManager.startScanButton')}
+						iconProps={circleIcon}
+						onClick={() => {
+							onTakePhotoClick()
+						}}
+					/>
+				</div>
+			</>
+		)
+	}
+)

--- a/packages/webapp/src/hooks/useTranslation.ts
+++ b/packages/webapp/src/hooks/useTranslation.ts
@@ -27,7 +27,8 @@ export enum Namespace {
 	PasswordReset = 'passwordReset',
 	Login = 'login',
 	Account = 'account',
-	Reporting = 'reporting'
+	Reporting = 'reporting',
+	Scan = 'scan'
 }
 
 function applyTemplate(message: string, options: Record<string, any> = {}) {

--- a/packages/webapp/src/locales/en-US/common.json
+++ b/packages/webapp/src/locales/en-US/common.json
@@ -37,7 +37,8 @@
     "accountText": "Account",
     "_accountText.comment": "Persona menu navigation item for Account page",
     "logoutText": "Logout",
-    "_logoutText.comment": "Persona menu navigation item for Logout user action"
+    "_logoutText.comment": "Persona menu navigation item for Logout user action",
+    "takePhoto": "Take Photo"
   },
   "mobileMenu": {
     "homePageLabel": "Dashboard",

--- a/packages/webapp/src/locales/en-US/scan.json
+++ b/packages/webapp/src/locales/en-US/scan.json
@@ -1,0 +1,16 @@
+{
+  "scanManager": {
+    "pageTitle": "Scan Manager",
+    "startScanButton": "Start Scan"
+  },
+  "scanImage": {
+    "pageTitle": "Scan Image",
+    "videoStremNotWorking": "Video stream not available.",
+    "takeMoreButton": "Take More",
+    "takePhotoButton": "Take Photo",
+    "turnOnFlashButton": "Flash",
+    "cancelButton": "Cancel",
+    "previewPhotoText": "1 photo complete.",
+    "doneUploadButton": "Done Upload"
+  }
+}

--- a/packages/webapp/src/pages/scanImage.tsx
+++ b/packages/webapp/src/pages/scanImage.tsx
@@ -1,0 +1,21 @@
+/*!
+ * Copyright (c) Microsoft. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project.
+ */
+import { Namespace, useTranslation } from '~hooks/useTranslation'
+import { ScanImageBody } from '~components/ui/ScanImageBody'
+import { wrap } from '~utils/appinsights'
+import { Title } from '~components/ui/Title'
+
+const ScanImagePage = wrap(function ScanImagePage() {
+	const { t } = useTranslation(Namespace.Scan)
+	const title = t('scanImage.pageTitle')
+	return (
+		<>
+			<Title title={title} />
+			<ScanImageBody />
+		</>
+	)
+})
+
+export default ScanImagePage

--- a/packages/webapp/src/pages/scanManager.tsx
+++ b/packages/webapp/src/pages/scanManager.tsx
@@ -1,0 +1,21 @@
+/*!
+ * Copyright (c) Microsoft. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project.
+ */
+import { Namespace, useTranslation } from '~hooks/useTranslation'
+import { ScanManagerBody } from '~components/ui/ScanManagerBody'
+import { wrap } from '~utils/appinsights'
+import { Title } from '~components/ui/Title'
+
+const ScanManagerPage = wrap(function ScanManagerPage() {
+	const { t } = useTranslation(Namespace.Scan)
+	const title = t('scanManager.pageTitle')
+	return (
+		<>
+			<Title title={title} />
+			<ScanManagerBody />
+		</>
+	)
+})
+
+export default ScanManagerPage

--- a/packages/webapp/src/types/ApplicationRoute.ts
+++ b/packages/webapp/src/types/ApplicationRoute.ts
@@ -17,5 +17,7 @@ export enum ApplicationRoute {
 	EditService = '/services/editService',
 	ServiceEntry = '/services/serviceEntry',
 	ServiceEntryKiosk = '/services/serviceEntryKiosk',
-	ServicesKiosk = '/servicesKiosk'
+	ServicesKiosk = '/servicesKiosk',
+	ScanManager = '/scanManager',
+	ScanImage = '/scanImage'
 }

--- a/packages/webapp/src/utils/config.ts
+++ b/packages/webapp/src/utils/config.ts
@@ -50,6 +50,7 @@ export interface Config {
 		redbox: FeatureFlag & { behavior: string | null }
 		beacon: FeatureFlag & { key: string | null }
 		offlineMode: FeatureFlag
+		takePhotoMode: FeatureFlag
 	}
 }
 


### PR DESCRIPTION
**What** 
 - Enable the user to take a photo using the laptop & tablet cameras

**Why**
- This is the first step to enable the user to scan documents 

**How**
- Using the WebRTC API to request for access to the Video streams from devices
- Then take a still image from the video that is shown to the user 

**Testing**
- the `takePhotoMode` flag for development should be true
- The camera on your desktop or tablet should show the image
- After taking the photo, the view will switch to the preview page

**Screenshots**
![image](https://user-images.githubusercontent.com/95376249/173675487-2d1f8d44-524a-4082-80b3-a3b79249478d.png)

![image](https://user-images.githubusercontent.com/95376249/173675626-3779bed0-a815-440f-9a8d-2213128361b3.png)

![image](https://user-images.githubusercontent.com/95376249/173675710-4d8d8d5f-4980-49c2-aebe-ffcb19cff348.png)

**Anything else**
 technical debts
 - media query needs to be added to change size for different devices
 - Take Photo Button needs to be disabled until video stream is playing
 - A simple flag for mobile testing needs to be added
 - Storing images
 - displaying list of stored images
 
 
 
