### PR TITLE
Services Page shows no results on initial load

### DIFF
--- a/packages/webapp/src/components/lists/ServiceList/index.tsx
+++ b/packages/webapp/src/components/lists/ServiceList/index.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft. All rights reserved.
  * Licensed under the MIT license. See LICENSE file in the project.
  */
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useEffect } from 'react'
 import styles from './index.module.scss'
 import type { StandardFC } from '~types/StandardFC'
 import { PaginatedList } from '~components/ui/PaginatedList'
@@ -44,6 +44,10 @@ export const ServiceList: StandardFC<ServiceListProps> = wrap(function ServiceLi
 
 	const { logout } = useAuthUser()
 	const onLogout = useNavCallback(ApplicationRoute.Logout)
+
+	useEffect(() => {
+		setFilteredList(services)
+	}, [services])
 
 	return (
 		<div


### PR DESCRIPTION
**What** 
 - Services page showed "no results..." message on initial load but services would appear after performing a search. Fixed so services are displayed on initial load

**Why**
 - So services are displayed as expected

**How**
 - `services` prop can be an empty array when `ServiceList` component is mounted. The component uses a `useState` variable to track filtered services and a `useState` variable can only be initialized once. Added a `useEffect` to update the filtered service list when `services` prop changes

**Testing**
 - to test, refresh the app, navigate to services page, ensure services list is displayed
