### PR TITLE
Allow offline mode to be enabled via github secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,8 @@ jobs:
           WEBAPP_ORIGIN: ${{ secrets.WEBAPP_ORIGIN }}
           WEBAPP_STORAGE_ACCOUNT: ${{ secrets.WEBAPP_STORAGE_ACCOUNT }}
           WEBAPP_STORAGE_KEY: ${{ secrets.WEBAPP_STORAGE_KEY }}
+          TAKE_PHOTO_MODE_ENABLED: ${{ secrets.TAKE_PHOTO_MODE_ENABLED }}
+          OFFLINE_MODE_ENABLED: ${{ secrets.OFFLINE_MODE_ENABLED }}
 
   deploy-staging:
     runs-on: ubuntu-latest
@@ -121,6 +123,8 @@ jobs:
           WEBAPP_ORIGIN: ${{ secrets.WEBAPP_ORIGIN }}
           WEBAPP_STORAGE_ACCOUNT: ${{ secrets.WEBAPP_STORAGE_ACCOUNT }}
           WEBAPP_STORAGE_KEY: ${{ secrets.WEBAPP_STORAGE_KEY }}
+          TAKE_PHOTO_MODE_ENABLED: ${{ secrets.TAKE_PHOTO_MODE_ENABLED }}
+          OFFLINE_MODE_ENABLED: ${{ secrets.OFFLINE_MODE_ENABLED }}
 
   deploy-demo:
     runs-on: ubuntu-latest
@@ -154,6 +158,8 @@ jobs:
           WEBAPP_ORIGIN: ${{ secrets.WEBAPP_ORIGIN }}
           WEBAPP_STORAGE_ACCOUNT: ${{ secrets.WEBAPP_STORAGE_ACCOUNT }}
           WEBAPP_STORAGE_KEY: ${{ secrets.WEBAPP_STORAGE_KEY }}
+          TAKE_PHOTO_MODE_ENABLED: ${{ secrets.TAKE_PHOTO_MODE_ENABLED }}
+          OFFLINE_MODE_ENABLED: ${{ secrets.OFFLINE_MODE_ENABLED }}
 
   deploy-production:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Added OFFLINE_MODE_ENABLED env var to integ/staging/demo sections ci.yml so the offline mode can be enabled via github secrets. I also added TAKE_PHOTO_MODE_ENABLED since that is present on staging branch.
