### PR TITLE
625 front end graphql storage

### DIFF
--- a/packages/webapp/src/api/local-forage-encrypted-wrapper.ts
+++ b/packages/webapp/src/api/local-forage-encrypted-wrapper.ts
@@ -5,7 +5,7 @@
 import { LocalForageWrapper } from 'apollo3-cache-persist'
 import * as CryptoJS from 'crypto-js'
 import { currentUserStore } from '~utils/current-user-store'
-import { checkSalt, setPwdHash, setCurrentUser, getCurrentUser } from '~utils/localCrypto'
+import { checkSalt, setPwdHash, getCurrentUser } from '~utils/localCrypto'
 
 export class LocalForageWrapperEncrypted extends LocalForageWrapper {
 	constructor(
@@ -16,7 +16,6 @@ export class LocalForageWrapperEncrypted extends LocalForageWrapper {
 		super(storage)
 		checkSalt(user)
 		setPwdHash(user, passwd)
-		setCurrentUser(user)
 	}
 
 	getItem(key: string): Promise<string | null> {

--- a/packages/webapp/src/components/forms/LoginForm/index.tsx
+++ b/packages/webapp/src/components/forms/LoginForm/index.tsx
@@ -24,7 +24,8 @@ import {
 	setCurrentUser,
 	checkSalt,
 	APOLLO_KEY,
-	setPwdHash
+	setPwdHash,
+	setPreQueueLoadRequired
 } from '~utils/localCrypto'
 import { createLogger } from '~utils/createLogger'
 import localforage from 'localforage'
@@ -54,6 +55,8 @@ export const LoginForm: StandardFC<LoginFormProps> = wrap(function LoginForm({
 			const resp = await login(values.username, values.password)
 
 			if (isDurableCacheEnabled) {
+				setPreQueueLoadRequired()
+				setCurrentUser(values.username)
 				const onlineAuthStatus = resp.status === 'SUCCESS'
 				const offlineAuthStatus = testPassword(values.username, values.password)
 				localUserStore.username = values.username

--- a/packages/webapp/src/utils/localCrypto.ts
+++ b/packages/webapp/src/utils/localCrypto.ts
@@ -23,16 +23,19 @@ const VERIFY_TEXT_KEY = '-verify'
  * @returns boolean - value that indicates if the salt had to be created (false) or exists (true)
  */
 const checkSalt = (userid: string): boolean => {
-	const saltKey = userid.concat(SALT_KEY)
-	const salt = window.localStorage.getItem(saltKey)
+	if (userid) {
+		const saltKey = userid.concat(SALT_KEY)
+		const salt = window.localStorage.getItem(saltKey)
 
-	if (!salt) {
-		const saltNew = bcrypt.genSaltSync(SALT_ROUNDS)
-		setSalt(saltKey, saltNew)
+		if (!salt) {
+			const saltNew = bcrypt.genSaltSync(SALT_ROUNDS)
+			setSalt(saltKey, saltNew)
 
-		return false
+			return false
+		}
+		return true
 	}
-	return true
+	return false
 }
 
 const setSalt = (saltKey: string, value: string) => {
@@ -44,16 +47,19 @@ const getSalt = (saltKey: string): string | void => {
 }
 
 const setPwdHash = (uid: string, pwd: string): boolean => {
-	const salt = getSalt(uid.concat(SALT_KEY))
-	if (!salt) {
-		return false
-	}
-	const hashPwd = bcrypt.hashSync(pwd, salt)
-	window.localStorage.setItem(uid.concat(HASH_PWD_KEY), hashPwd)
+	if (uid) {
+		const salt = getSalt(uid.concat(SALT_KEY))
+		if (!salt) {
+			return false
+		}
+		const hashPwd = bcrypt.hashSync(pwd, salt)
+		window.localStorage.setItem(uid.concat(HASH_PWD_KEY), hashPwd)
 
-	const edata = CryptoJS.AES.encrypt(VERIFY_TEXT, getPwdHash(uid)).toString()
-	window.localStorage.setItem(uid.concat(VERIFY_TEXT_KEY), edata)
-	return true
+		const edata = CryptoJS.AES.encrypt(VERIFY_TEXT, getPwdHash(uid)).toString()
+		window.localStorage.setItem(uid.concat(VERIFY_TEXT_KEY), edata)
+		return true
+	}
+	return false
 }
 
 const testPassword = (uid: string, passwd: string) => {

--- a/packages/webapp/src/utils/localCrypto.ts
+++ b/packages/webapp/src/utils/localCrypto.ts
@@ -15,6 +15,7 @@ const REQUEST_QUEUE_KEY = '-request-queue'
 const PRE_QUEUE_REQUEST_KEY = '-pre-queue-request'
 const VERIFY_TEXT = 'DECRYPT ME'
 const VERIFY_TEXT_KEY = '-verify'
+const PRE_QUEUE_LOAD_REQUIRED = 'pre-queue-load-required'
 /**
  * Check if a salt value has been stored for the given user. Each user will need a salt value to generate an encrypted
  * password that will be stored in the session to allow decryption of the apollo persistent cache.
@@ -103,8 +104,8 @@ const setCurrentRequestQueue = (queue: string): boolean => {
 	return setQueue(queue, REQUEST_QUEUE_KEY)
 }
 
-const setPreQueueRequest = (queue: string): boolean => {
-	return setQueue(queue, PRE_QUEUE_REQUEST_KEY)
+const setPreQueueRequest = (queue: any[]): boolean => {
+	return setQueue(JSON.stringify(queue), PRE_QUEUE_REQUEST_KEY)
 }
 
 const setQueue = (queue: string, key: string): boolean => {
@@ -124,8 +125,12 @@ const getCurrentRequestQueue = (): string => {
 	return getQueue(REQUEST_QUEUE_KEY)
 }
 
-const getPreQueueRequest = (): string => {
-	return getQueue(PRE_QUEUE_REQUEST_KEY)
+const getPreQueueRequest = (): any[] => {
+	const requests = getQueue(PRE_QUEUE_REQUEST_KEY)
+	if (requests) {
+		return JSON.parse(requests)
+	}
+	return []
 }
 
 const getQueue = (key: string): string => {
@@ -156,6 +161,32 @@ const clearCurrentRequestQueue = (): boolean => {
 	return false
 }
 
+const clearPreQueueRequest = (): boolean => {
+	const uid = getCurrentUser()
+
+	if (uid) {
+		window.localStorage.removeItem(uid.concat(PRE_QUEUE_REQUEST_KEY))
+		return true
+	}
+	return false
+}
+
+const setPreQueueLoadRequired = (): void => {
+	window.localStorage.setItem(PRE_QUEUE_LOAD_REQUIRED, 'true')
+}
+
+const clearPreQueueLoadRequired = (): void => {
+	window.localStorage.setItem(PRE_QUEUE_LOAD_REQUIRED, 'false')
+}
+
+const getPreQueueLoadRequired = (): boolean => {
+	const setting = window.localStorage.getItem(PRE_QUEUE_LOAD_REQUIRED)
+	if (setting) {
+		return setting === 'true'
+	}
+	return false
+}
+
 export {
 	setCurrentUser,
 	getCurrentUser,
@@ -171,5 +202,9 @@ export {
 	clearCurrentRequestQueue,
 	getPreQueueRequest,
 	setPreQueueRequest,
+	clearPreQueueRequest,
+	setPreQueueLoadRequired,
+	clearPreQueueLoadRequired,
+	getPreQueueLoadRequired,
 	APOLLO_KEY
 }

--- a/packages/webapp/src/utils/queueLink.ts
+++ b/packages/webapp/src/utils/queueLink.ts
@@ -82,7 +82,9 @@ export default class QueueLink extends ApolloLink {
 					listener({ operation, forward, observer })
 				})
 			}
-			forward(operation).subscribe(observer)
+			if (forward) {
+				forward(operation).subscribe(observer)
+			}
 		})
 	}
 
@@ -146,6 +148,13 @@ export default class QueueLink extends ApolloLink {
 		this.opQueue.push(entry)
 		if (this.isDurableCacheEnabled) {
 			setCurrentRequestQueue(JSON.stringify(this.opQueue))
+			// setCurrentRequestQueue(JSON.stringify(this.opQueue, (key, value) => {
+			// 	if (typeof value === 'function') {
+			// 		return `return ${value.toString()}`;
+			// 	} else {
+			// 	  	return value;
+			// 	}
+			// }))
 		}
 
 		const key: string = QueueLink.key(entry.operation.operationName, 'enqueue')
@@ -167,6 +176,12 @@ export default class QueueLink extends ApolloLink {
 		const savedQueueS = getCurrentRequestQueue()
 		if (savedQueueS) {
 			const combined = this.opQueue.concat(JSON.parse(savedQueueS))
+
+			// const savedQueueObjects = JSON.parse(savedQueueS).map((savedQueue) => {
+			// 	savedQueue.forward = new Function(savedQueue.forward)()
+			// 	return savedQueue
+			// })
+			// const combined = this.opQueue.concat(savedQueueObjects)
 			setCurrentRequestQueue(JSON.stringify(combined))
 			return combined.filter((item, index) => combined.indexOf(item) === index)
 		} else {

--- a/packages/webapp/src/utils/queueLink.ts
+++ b/packages/webapp/src/utils/queueLink.ts
@@ -7,6 +7,10 @@ import type { Operation, FetchResult, NextLink, DocumentNode } from '@apollo/cli
 import { ApolloLink } from '@apollo/client/link/core'
 import type { Observer } from '@apollo/client/utilities'
 import { Observable } from '@apollo/client/utilities'
+import { config } from '~utils/config'
+import localForage from 'localforage'
+import { LocalForageWrapperEncrypted } from '../api/local-forage-encrypted-wrapper'
+import { getCurrentUser } from '~utils/localCrypto'
 
 export interface OperationQueueEntry {
 	operation: Operation
@@ -22,6 +26,24 @@ export default class QueueLink extends ApolloLink {
 	static filter: OperationTypeNode[] = null
 	private opQueue: OperationQueueEntry[] = []
 	private isOpen = true
+	private readonly isDurableCacheEnabled: boolean
+	private readonly localForageSecureKey = 'offline-request'
+	private readonly currentUser
+	private localForageSecure: LocalForageWrapperEncrypted
+
+	constructor() {
+		super()
+		this.isDurableCacheEnabled = Boolean(config.features.durableCache.enabled)
+		if (this.isDurableCacheEnabled) {
+			this.currentUser = getCurrentUser()
+			this.localForageSecure = new LocalForageWrapperEncrypted(localForage, this.currentUser)
+			this.localForageSecure.getItem(this.localForageSecureKey).then((item) => {
+				if (item) {
+					this.opQueue = JSON.parse(item)
+				}
+			})
+		}
+	}
 
 	public getQueue(): OperationQueueEntry[] {
 		return this.opQueue
@@ -48,6 +70,10 @@ export default class QueueLink extends ApolloLink {
 		this.isOpen = true
 		const opQueueCopy = [...this.opQueue]
 		this.opQueue = []
+		if (this.isDurableCacheEnabled) {
+			this.localForageSecure.removeItem(this.localForageSecureKey)
+		}
+
 		opQueueCopy.forEach(({ operation, forward, observer }) => {
 			const key: string = QueueLink.key(operation.operationName, 'dequeue')
 			if (key in QueueLink.listeners) {
@@ -114,6 +140,9 @@ export default class QueueLink extends ApolloLink {
 
 	private enqueue(entry: OperationQueueEntry) {
 		this.opQueue.push(entry)
+		if (this.isDurableCacheEnabled) {
+			this.localForageSecure.setItem(this.localForageSecureKey, JSON.stringify(this.opQueue))
+		}
 
 		const key: string = QueueLink.key(entry.operation.operationName, 'enqueue')
 		if (key in QueueLink.listeners) {


### PR DESCRIPTION
**What** 
Ensure that requests submitted during an offline session are not lost if the browser is closed

**Why**
Users are expected to complete data entry even if the network is down

**How**
Current offline queue (apollo queue) will hold requests in a customized link object.  Once online, the queue will process the requests per usual.  If the browser is closed the data is lost.

This approach creates a "pre-queue" that retains the original simple data from the form in an array that has been encrypted and saved to local storage.  If the browser is re-started, the queue is restored and the entries are sent for processing.  The pre-queue is cleared when the data has been saved.


What to test:

Note: this is only available if the durableCache has been enabled.

1. Ensure online operation of requests succeeds.
2. Switch to offline mode, create a request, not that is is retained in the interface is "local" status.
3. Switch back to online mode and notice the request status has changed and the data has been saved to the server.
4. Switch to offline mode, create new request.
5. logout and close browser.
6. Login (offline still) and note that the request still exists (status is still local).
7. Switch to online and notice the status has changed indicating it has been saved.

Note: Testing of steps 4-7 depend on merging with PR 655 (offline login)
