### PR TITLE
fix OCR url

### DIFF
--- a/packages/webapp/workers/app.sw.tmpl
+++ b/packages/webapp/workers/app.sw.tmpl
@@ -11,6 +11,7 @@ const noCacheURLS = [
 	<%= urlAPI %>,
 	"visualstudio.com",
 	"beacon-v2.helpscout.net",
+	"cbo-ops-suite.azurewebsites.net"
 ];
 
 /* 


### PR DESCRIPTION
**What** 
Add the OCR _Azure Functions App_ url to the Service Workers no cach list to avoid Fetch Response errors.
